### PR TITLE
Implement replacement for Immutables generator

### DIFF
--- a/api/src/main/java/telegram4j/tl/api/TlEncodingUtil.java
+++ b/api/src/main/java/telegram4j/tl/api/TlEncodingUtil.java
@@ -5,9 +5,10 @@ import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledHeapByteBuf;
 import reactor.util.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /** Utility methods for encodings module. */
 public class TlEncodingUtil {
@@ -23,21 +24,32 @@ public class TlEncodingUtil {
         return Unpooled.unreleasableBuffer(Unpooled.copiedBuffer(value).asReadOnly());
     }
 
-    public static <T> List<T> unmodifiableList(@Nullable List<? extends T> list) {
-        if (list == null) {
-            return Collections.emptyList();
-        }
+    public static int mask(int flags, int mask, boolean state) {
+        return state ? flags | mask : flags & ~mask;
+    }
 
-        switch (list.size()) {
-            case 0:
-                return Collections.emptyList();
-            case 1:
-                return Collections.singletonList(list.get(0));
-            default:
-                if (list instanceof ArrayList<?>) {
-                    ((ArrayList<?>) list).trimToSize();
-                }
-                return Collections.unmodifiableList(list);
+    public static boolean eq(boolean present, boolean value, @Nullable Boolean newValue) {
+        return !present && newValue == null || newValue != null && newValue == value;
+    }
+
+    public static boolean eq(boolean present, int value, @Nullable Integer newValue) {
+        return !present && newValue == null || newValue != null && newValue == value;
+    }
+
+    public static boolean eq(boolean present, long value, @Nullable Long newValue) {
+        return !present && newValue == null || newValue != null && newValue == value;
+    }
+
+    public static boolean eq(boolean present, double value, @Nullable Double newValue) {
+        return !present && newValue == null || newValue != null && newValue.equals(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> copyList(Iterable<? extends T> values) {
+        if (values instanceof Collection<?>) {
+            return List.copyOf((Collection<? extends T>) values);
         }
+        return StreamSupport.stream(values.spliterator(), false)
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,7 @@ ext {
     jackson_version = '2.13.3'
     immutables_version = '2.9.0'
     javax_annotation = '1.3.2'
-    junit_version = '5.8.2'
-    javapoet_version = '1.13.0'
+    junit_version = '5.9.0'
 
     isJitpack = System.getenv("JITPACK") == "true"
     isSnapshot = version.toString().endsWith("-SNAPSHOT")
@@ -19,10 +18,8 @@ dependencies {
     compileOnly project(":encoding")
 
     api "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jackson_version"
+
     compileOnly "javax.annotation:javax.annotation-api:$javax_annotation"
-    compileOnly "org.immutables:value:$immutables_version"
-    annotationProcessor "org.immutables:value:$immutables_version"
     compileOnly project(":parser")
     annotationProcessor project(":parser")
 
@@ -186,4 +183,7 @@ configure(subprojects - project(":parser") + project){
     }
 }
 
-sourceSets.main.java.srcDirs += "build/generated/sources/annotationProcessor/java/main"
+sourcesJar {
+    dependsOn compileJava
+    from "$buildDir/generated/sources/annotationProcessor/java/main"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 ext {
     reactor_bom_version = '2020.0.22'
-    jackson_version = '2.13.3'
+    jackson_version = '2.13.4'
     immutables_version = '2.9.0'
     javax_annotation = '1.3.2'
     junit_version = '5.9.0'
@@ -38,7 +38,7 @@ allprojects {
         apply plugin: 'signing'
     }
 
-    group = 'io.github.telegram4j'
+    group = 'com.telegram4j'
     description = 'Telegram API schema parser'
 
     targetCompatibility = JavaVersion.VERSION_11

--- a/encoding/src/main/java/telegram4j/tl/encoding/ByteBufEncoding.java
+++ b/encoding/src/main/java/telegram4j/tl/encoding/ByteBufEncoding.java
@@ -41,6 +41,7 @@ public class ByteBufEncoding {
         @Encoding.Init
         @Encoding.Copy
         public void set(ByteBuf value) {
+            java.lang.reflect.Array.newInstance(Integer.class, 1);
             this.value = TlEncodingUtil.copyAsUnpooled(value);
         }
 

--- a/encoding/src/main/java/telegram4j/tl/encoding/ByteBufEncoding.java
+++ b/encoding/src/main/java/telegram4j/tl/encoding/ByteBufEncoding.java
@@ -41,7 +41,6 @@ public class ByteBufEncoding {
         @Encoding.Init
         @Encoding.Copy
         public void set(ByteBuf value) {
-            java.lang.reflect.Array.newInstance(Integer.class, 1);
             this.value = TlEncodingUtil.copyAsUnpooled(value);
         }
 

--- a/encoding/src/main/java/telegram4j/tl/encoding/ListByteBufEncoding.java
+++ b/encoding/src/main/java/telegram4j/tl/encoding/ListByteBufEncoding.java
@@ -7,7 +7,6 @@ import telegram4j.tl.api.TlEncodingUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -93,7 +92,7 @@ public class ListByteBufEncoding {
 
         @Encoding.Build
         List<ByteBuf> build() {
-            return TlEncodingUtil.unmodifiableList(value);
+            return TlEncodingUtil.copyList(value);
         }
     }
 }

--- a/encoding/src/main/java/telegram4j/tl/encoding/OptionalListByteBufEncoding.java
+++ b/encoding/src/main/java/telegram4j/tl/encoding/OptionalListByteBufEncoding.java
@@ -113,7 +113,7 @@ public class OptionalListByteBufEncoding {
 
         @Encoding.Build
         List<ByteBuf> build() {
-            return value.map(TlEncodingUtil::unmodifiableList).orElse(null);
+            return value.map(TlEncodingUtil::copyList).orElse(null);
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.daemon = false
 org.gradle.jvmargs = -Xms256m -Xmx1024m
 version = 0.1.1-SNAPSHOT
+org.gradle.java.home = /usr/lib/jvm/java-11-openjdk/

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -2,14 +2,12 @@ dependencies {
     compileOnly project(":encoding")
     api project(":api")
 
-    implementation "com.squareup:javapoet:$javapoet_version"
     compileOnly "org.immutables:value:$immutables_version"
     annotationProcessor "org.immutables:value:$immutables_version"
 
     api "io.projectreactor.addons:reactor-extra"
 
     api "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jackson_version"
 
     compileOnly "javax.annotation:javax.annotation-api:$javax_annotation"
 

--- a/parser/src/main/java/telegram4j/tl/generator/Depluralizer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/Depluralizer.java
@@ -1,0 +1,29 @@
+package telegram4j.tl.generator;
+
+import java.util.function.UnaryOperator;
+
+public class Depluralizer implements UnaryOperator<String> {
+    private static final Naming NAMING_S_PLURAL = Naming.from("*s");
+    private static final Naming NAMING_IES_PLURAL = Naming.from("*ies");
+
+    private static final Depluralizer instance = new Depluralizer();
+
+    private Depluralizer() {}
+
+    public static Depluralizer instance() {
+        return instance;
+    }
+
+    @Override
+    public String apply(String s) {
+        String detected = NAMING_IES_PLURAL.detect(s);
+        if (detected != null) {
+            return detected + "y";
+        }
+        detected = NAMING_S_PLURAL.detect(s);
+        if (detected != null) {
+            return detected;
+        }
+        return s;
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/Depluralizer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/Depluralizer.java
@@ -18,7 +18,7 @@ public class Depluralizer implements UnaryOperator<String> {
     public String apply(String s) {
         String detected = NAMING_IES_PLURAL.detect(s);
         if (detected != null) {
-            return detected + "y";
+            return detected + 'y';
         }
         detected = NAMING_S_PLURAL.detect(s);
         if (detected != null) {

--- a/parser/src/main/java/telegram4j/tl/generator/FileService.java
+++ b/parser/src/main/java/telegram4j/tl/generator/FileService.java
@@ -1,0 +1,30 @@
+package telegram4j.tl.generator;
+
+import telegram4j.tl.generator.renderer.TopLevelRenderer;
+
+import javax.annotation.processing.Filer;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+
+public class FileService {
+    private final Filer filer;
+
+    public FileService(Filer filer) {
+        this.filer = filer;
+    }
+
+    public void writeTo(TopLevelRenderer renderer) {
+        CharSequence seq = renderer.complete();
+        try {
+            String filename = renderer.name.qualifiedName().replace('/', '.');
+            JavaFileObject fo = filer.createSourceFile(filename);
+            try (Writer w = fo.openWriter()) {
+                w.append(seq);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/ImmutableGenerator.java
+++ b/parser/src/main/java/telegram4j/tl/generator/ImmutableGenerator.java
@@ -1,0 +1,1152 @@
+package telegram4j.tl.generator;
+
+import io.netty.buffer.ByteBufUtil;
+import reactor.util.annotation.Nullable;
+import telegram4j.tl.api.TlEncodingUtil;
+import telegram4j.tl.generator.renderer.*;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static telegram4j.tl.generator.SchemaGeneratorConsts.*;
+import static telegram4j.tl.generator.SchemaGeneratorConsts.Style.*;
+
+class ImmutableGenerator {
+    // At the moment there known one *serious* mistake in design of immutable classes.
+    // We allow users to change flags:# fields for the sake of convenient initialization of bit flags (flags.num?true type)
+    // But at the same time users can change bits of the optional fields,
+    // initialization of which has ambiguous behavior depending on the type
+    // (primitive fields depends on bits (expected behavior), and reference fields depends on null-reference and just ignore
+    // bits in the builder constructor for better *performance*)
+    // ^ it seems that this can be easily fixed, but I will deal with it later
+
+    private static final ClassRef UTILITY = ClassRef.of(TlEncodingUtil.class);
+
+    private final FileService fileService;
+    private final Elements elements;
+
+    ImmutableGenerator(FileService fileService, Elements elements) {
+        this.fileService = fileService;
+        this.elements = elements;
+    }
+
+    public void process(ValueType type) {
+
+        var renderer = ClassRenderer.create(type.immutableType.rawType, ClassRenderer.Kind.CLASS)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addTypeVariables(type.typeVars)
+                .addInterface(type.baseType);
+
+        // to simplify further generation
+        if (type.attributes.isEmpty()) {
+            generateEmpty(type, renderer);
+
+            fileService.writeTo(renderer);
+            return;
+        }
+
+        CompletionDeferrer pending = new CompletionDeferrer();
+        boolean singleton = type.flags.contains(ValueType.Flag.SINGLETON);
+
+        // region generate fields
+        if (singleton) { // TODO: unhandled generics
+            renderer.addField(type.immutableType, "INSTANCE", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                    .initializer("new $T()", type.immutableType)
+                    .complete();
+        }
+
+        for (ValueAttribute a : type.generated) {
+            renderer.addField(unboxOptional(a), a.name, Modifier.PRIVATE, Modifier.FINAL).complete();
+        }
+        // endregion
+
+        // region constructors
+
+        if (singleton) {
+            var singletonConstructor = renderer.addConstructor(Modifier.PRIVATE);
+
+            for (ValueAttribute a : type.generated) {
+                TypeRef unwrapped = unboxOptional(a);
+                singletonConstructor.addStatement("$L = $L", a.name, defaultValueFor(unwrapped));
+            }
+
+            singletonConstructor.complete();
+        }
+
+        // constructor with mandatory parameters
+        var mandatoryConstructorBody = renderer.createCode().incIndent(2);
+        var mandatoryConstructor = renderer.addConstructor(Modifier.PRIVATE);
+
+        var mandatoryOf = renderer.addMethod(type.immutableType, "of", Modifier.PUBLIC, Modifier.STATIC)
+                .addTypeVariables(type.typeVars);
+
+        StringJoiner params = new StringJoiner(", ");
+
+        // I want to initialize the fields in order:
+        // [ mandatory fields ]
+        // \n
+        // [ optional fields ]
+
+        var sorted = type.generated.stream()
+                .sorted(Comparator.comparingInt(d -> d.flags.contains(ValueAttribute.Flag.OPTIONAL) ? 1 : 0))
+                .collect(Collectors.toList());
+
+        for (int i = 0, n = sorted.size(); i < n; i++) {
+            ValueAttribute a = sorted.get(i);
+
+            if (!a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                TypeRef listElement = unwrap(a.type, LIST);
+                TypeRef paramType = a.type;
+                if (listElement != a.type) // Iterable<? extends ParamType>
+                    paramType = ParameterizedTypeRef.of(ITERABLE, expandBounds(listElement));
+
+                mandatoryConstructor.addParameter(paramType, a.name);
+
+                if (a.type instanceof PrimitiveTypeRef) {
+                    mandatoryConstructorBody.addStatement("this.$1L = $1L", a.name);
+                } else if (listElement != a.type) {
+                    if (listElement == BYTE_BUF) {
+                        mandatoryConstructorBody.addStatement("this.$1L = $2T.stream($1L.spliterator(), false)$B" +
+                                ".map($3T::copyAsUnpooled)$B.collect($4T.toUnmodifiableList())",
+                                a.name, StreamSupport.class, UTILITY, Collectors.class);
+                    } else {
+                        mandatoryConstructorBody.addStatement("this.$1L = $2T.copyList($1L)", a.name, UTILITY);
+                    }
+                } else if (a.type == BYTE_BUF) {
+                    mandatoryConstructorBody.addStatement("this.$1L = $2T.copyAsUnpooled($1L)", a.name, UTILITY);
+                } else {
+                    mandatoryConstructorBody.addStatement("this.$1L = $2T.requireNonNull($1L)", a.name, Objects.class);
+                }
+
+                params.add(a.name);
+                mandatoryOf.addParameter(paramType, a.name);
+
+                if (i + 1 < n && sorted.get(i + 1).flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                    mandatoryConstructorBody.ln();
+                }
+            } else {
+                TypeRef unwrapped = unboxOptional(a);
+                mandatoryConstructorBody.addStatement("$L = $L", a.name, defaultValueFor(unwrapped));
+            }
+        }
+
+        if (singleton) {
+            mandatoryOf.addStatement("return canonize(new $T($L))", type.immutableType, params);
+        } else {
+            mandatoryOf.addStatement("return new $T($L)", type.immutableType, params);
+        }
+
+        mandatoryConstructor.addCode(mandatoryConstructorBody.complete());
+        mandatoryConstructor.complete();
+
+        var builderConstructor = renderer.addConstructor(Modifier.PRIVATE)
+                .addParameter(type.builderType, "builder");
+
+        for (ValueAttribute a : type.generated) {
+            StringBuilder format = new StringBuilder("this.$1L = ");
+            if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                if (a.type.safeUnbox() instanceof PrimitiveTypeRef) {
+                    format.append("(builder.$2L & $3L) != 0 ? ");
+                } else {
+                    format.append("builder.$1L != null ? ");
+                }
+            }
+
+            if (unwrap(a.type, LIST) != a.type) {
+                format.append("$4T.copyOf(builder.$1L)");
+            } else {
+                format.append("builder.$1L");
+            }
+
+            if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                format.append(" : ").append(defaultValueFor(a.type.safeUnbox()));
+            }
+
+            builderConstructor.addStatement(format, a.name, a.flagsName, a.flagMask, LIST);
+        }
+
+        builderConstructor.complete();
+
+        // constructor for with* methods
+
+        // - no reference fields
+        // - no optional fields
+        if (!type.canOmitCopyConstr) {
+            var allConstructorBody = renderer.createCode().incIndent(2);
+            var allConstructor = renderer.addConstructor(Modifier.PRIVATE);
+
+            // have a reference fields, need to stub.
+            // This is necessary because this constructor does not contain null checks
+            if (type.needStubParam) {
+                allConstructor.addParameter(Void.class, "synthetic0");
+            }
+
+            for (ValueAttribute a : type.generated) {
+                allConstructor.addParameter(unboxOptional(a), a.name);
+                allConstructorBody.addStatement("this.$1L = $1L", a.name);
+            }
+
+            allConstructor.addCode(allConstructorBody.complete());
+            allConstructor.complete();
+        }
+
+        // endregion
+
+        // region static methods
+
+        if (singleton) { // unhandled possible generics
+            renderer.addMethod(type.immutableType, "canonize", Modifier.PRIVATE, Modifier.STATIC)
+                    .addParameter(type.immutableType, "instance")
+                    .addStatement("return INSTANCE.equals(instance) ? INSTANCE : instance")
+                    .complete();
+
+            renderer.addMethod(type.immutableType, "of", Modifier.PUBLIC, Modifier.STATIC)
+                    .addStatement("return INSTANCE")
+                    .complete();
+        }
+
+        mandatoryOf.complete();
+
+        var copyOf = renderer.addMethod(type.immutableType, "copyOf", Modifier.PUBLIC, Modifier.STATIC)
+                .addTypeVariables(type.typeVars)
+                .addParameter(type.immutableType, "instance")
+                .addStatement("$T.requireNonNull(instance)", Objects.class)
+                .beginControlFlow("if (instance instanceof $T) {", type.immutableType.withTypeArguments(
+                        Collections.nCopies(type.typeVars.size(), WildcardTypeRef.none())))
+                .addStatement("return ($T) instance", type.immutableType)
+                .endControlFlow();
+
+        if (!type.typeVars.isEmpty()) {
+            copyOf.addStatement("return $L.<$L>builder().from(instance).build()",
+                    type.immutableType.rawType, type.typeVarNames.stream()
+                            .map(r -> r.name)
+                            .collect(Collectors.joining(", ")));
+        } else {
+            copyOf.addStatement("return builder().from(instance).build()");
+        }
+
+        copyOf.complete();
+
+        renderer.addMethod(type.builderType, "builder", Modifier.PUBLIC, Modifier.STATIC)
+                .addTypeVariables(type.typeVars)
+                .addStatement("return new Builder()")
+                .complete();
+
+        // endregion
+
+        // region interface methods
+
+        renderer.addMethod(int.class, "identifier")
+                .addAnnotations(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addStatement("return ID")
+                .complete();
+
+        for (ValueAttribute a : type.attributes) {
+            var attr = renderer.addMethod(a.type, a.name);
+            if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                attr.addAnnotations(Nullable.class);
+            }
+
+            attr.addAnnotations(Override.class);
+            attr.addModifiers(Modifier.PUBLIC);
+
+            if (a.flags.contains(ValueAttribute.Flag.BIT_FLAG)) {
+                attr.addStatement("return ($L & $L) != 0", a.flagsName(), a.flagMask());
+            } else {
+                TypeRef listElement = unwrap(a.type, LIST);
+
+                boolean opt = a.flags.contains(ValueAttribute.Flag.OPTIONAL);
+                StringBuilder format = new StringBuilder("return ");
+                if (opt && listElement == BYTE_BUF) {
+                    format.append("$L != null ? ");
+                } else if (opt && a.type.safeUnbox() instanceof PrimitiveTypeRef) {
+                    format.append("($2L & $3L) != 0 ? ");
+                }
+
+                if (listElement != a.type &&
+                    listElement == BYTE_BUF) {
+                    // I then rewrite to explicit imports
+                    format.append("$1L.stream().map(ByteBuf::duplicate).collect(Collectors.toList())");
+                } else if (a.type == BYTE_BUF) {
+                    format.append("$1L.duplicate()");
+                } else {
+                    format.append("$1L");
+                }
+
+                if (opt && (listElement == BYTE_BUF || a.type.safeUnbox() instanceof PrimitiveTypeRef)) {
+                    format.append(" : null");
+                }
+
+                attr.addStatement(format, a.name, a.flagsName, a.flagMask);
+            }
+            attr.complete();
+        }
+
+        // endregion
+
+        // region with* methods
+
+        for (ValueAttribute a : type.attributes) {
+            generateWither(type, a, renderer, pending);
+
+            pending.complete();
+        }
+
+        // endregion
+
+        // region object methods
+
+        var unbounded = type.baseType.withTypeArguments(
+                Collections.nCopies(type.typeVars.size(), WildcardTypeRef.none()));
+        var equals = renderer.addMethod(boolean.class, "equals")
+                .addAnnotations(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(ClassRef.OBJECT, "o")
+                .addStatement("if (this == o) return true")
+                .addStatement("if (!(o instanceof $T)) return false", unbounded)
+                .addStatement("$1T $2L = ($1T) o", unbounded, type.equalsName)
+                .addCode("return ID == $L.identifier() &&", type.equalsName).incIndent(2).ln();
+
+        var hashCode = renderer.addMethod(int.class, "hashCode")
+                .addAnnotations(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addStatement("int $L = 5381", type.hashCodeName)
+                .addStatement("$1L += ($1L << 5) + ID", type.hashCodeName);
+
+        var toString = renderer.addMethod(STRING, "toString")
+                .addAnnotations(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addCode("return \"$L#$L{\" +", type.baseType.rawType.name, type.tlType.id)
+                .incIndent(2).ln();
+
+        for (int i = 0, n = type.generated.size(); i < n; i++) {
+            ValueAttribute a = type.generated.get(i);
+
+            TypeRef unwrapped = unboxOptional(a);
+
+            // region hashCode
+            if (unwrapped == PrimitiveTypeRef.DOUBLE) {
+                hashCode.addStatement("$1L += ($1L << 5) + Double.hashCode($2L)", type.hashCodeName, a.name);
+            } else if (unwrapped == PrimitiveTypeRef.INT) {
+                hashCode.addStatement("$1L += ($1L << 5) + $2L", type.hashCodeName, a.name);
+            } else if (unwrapped == PrimitiveTypeRef.BOOLEAN) {
+                if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                    hashCode.addStatement("$1L += ($1L << 5) + (this." + a.flagsName() + " & " + a.flagMask()
+                            + ") != 0 ? Boolean.hashCode($2L) : 0", type.hashCodeName, a.name);
+                } else {
+                    hashCode.addStatement("$1L += ($1L << 5) + Boolean.hashCode($2L)", type.hashCodeName, a.name);
+                }
+            } else if (unwrapped == PrimitiveTypeRef.LONG) {
+                hashCode.addStatement("$1L += ($1L << 5) + Long.hashCode($2L)", type.hashCodeName, a.name);
+            } else if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                hashCode.addStatement("$1L += ($1L << 5) + $2T.hashCode($3L)", type.hashCodeName, Objects.class, a.name);
+            } else {
+                hashCode.addStatement("$1L += ($1L << 5) + $2L.hashCode()", type.hashCodeName, a.name);
+            }
+
+            // endregion
+
+            // region equals
+
+            if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                equals.addCode("$T.equals($2L(), $3L.$2L())", Objects.class, a.name, type.equalsName);
+            } else if (unwrapped == PrimitiveTypeRef.DOUBLE) {
+                equals.addCode("Double.doubleToLongBits($1L) == Double.doubleToLongBits($2L.$1L())", a.name, type.equalsName);
+            } else if (unwrapped instanceof PrimitiveTypeRef) {
+                equals.addCode("$1L == $2L.$1L()", a.name, type.equalsName);
+            } else {
+                equals.addCode("$1L.equals($2L.$1L())", a.name, type.equalsName);
+            }
+
+            if (i != n - 1) {
+                equals.addCode(" &&").ln();
+            }
+
+            // endregion
+
+            // region toString
+
+            if (i != 0) {
+                boolean isPrevStr = type.generated.get(i - 1).type == STRING;
+
+                if (isPrevStr) {
+                    toString.addCode("\"', ");
+                } else {
+                    toString.addCode("\", ");
+                }
+            } else {
+                toString.addCode('"');
+            }
+
+            boolean isString = unwrapped == STRING;
+            toString.addCode(a.name);
+            if (isString) {
+                toString.addCode("='\" + ");
+            } else {
+                toString.addCode("=\" + ");
+            }
+
+            TypeRef listElement = unwrap(a.type, LIST);
+
+            if (a.flags.contains(ValueAttribute.Flag.OPTIONAL) && unwrapped instanceof PrimitiveTypeRef) {
+                toString.addCode("(($L & $L) != 0 ? $L : \"null\")", a.flagsName(), a.flagMask(), a.name);
+            } else if (a.flags.contains(ValueAttribute.Flag.BIT_SET)) {
+                toString.addCode("Integer.toBinaryString($L)", a.name);
+            } else if (listElement == BYTE_BUF) {
+                StringBuilder format = new StringBuilder();
+                if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                    format.append("($1L != null ? ");
+                }
+
+                if (listElement != a.type) {
+                    format.append("$1L.stream()$B.map($2T::hexDump)$B.collect($3T.joining(\", \", \"[\", \"]\"))");
+                } else {
+                    format.append("$2T.hexDump($1L)");
+                }
+
+                if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                    format.append(" : \"null\")");
+                }
+                toString.addCode(format, a.name, ByteBufUtil.class, Collectors.class);
+            } else {
+                toString.addCode(a.name);
+            }
+
+            toString.addCode(" +").ln();
+
+            // endregion
+        }
+
+        equals.decIndent(2).addCode(';');
+
+        hashCode.addStatement("return $L", type.hashCodeName);
+
+        toString.addCode("'}';").decIndent(2);
+
+        equals.complete();
+        hashCode.complete();
+        toString.complete();
+
+        // endregion
+
+        // region builder
+
+        var builder = renderer.addType("Builder", ClassRenderer.Kind.CLASS)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .addTypeVariables(type.typeVars);
+
+        TypeRef bitsType = floorBitFlagsType(type.initBitsCount);
+
+        if (type.initBitsCount > 0) {
+            short pos = 0;
+            for (ValueAttribute a : type.attributes) {
+                if (!a.flags.isEmpty()) {
+                    continue;
+                }
+
+                builder.addField(bitsType, a.names.initBit, Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                        .initializer("0x" + Integer.toHexString(1 << pos++))
+                        .complete();
+            }
+
+            builder.addField(bitsType, "initBits", Modifier.PRIVATE)
+                    .initializer("0x" + Integer.toHexString(~(~0 << type.initBitsCount)))
+                    .complete();
+        }
+
+        pending.add(builder.addConstructor(Modifier.PRIVATE));
+        generateFrom(type, builder, pending);
+
+        for (ValueAttribute a : type.attributes) {
+            generateSetter(type, a, builder, pending);
+        }
+
+        pending.complete();
+
+        var build = builder.addMethod(type.immutableType, "build", Modifier.PUBLIC);
+
+        // endregion
+
+        if (type.initBitsCount > 0) {
+            var initializationIncomplete = builder.addMethod(
+                    IllegalStateException.class, "initializationIncomplete", Modifier.PRIVATE)
+                    .addStatement("$T<String> attributes = new $T<>($L(initBits))",
+                            LIST, ArrayList.class, bitsCountMethod(type.initBitsCount));
+
+            pending.add(initializationIncomplete);
+
+            for (ValueAttribute a : type.attributes) {
+                if (!a.flags.isEmpty()) {
+                    continue;
+                }
+
+                initializationIncomplete.addStatement("if ((initBits & $L) != 0) attributes.add($S)", a.names.initBit, a.name);
+            }
+
+            initializationIncomplete.addStatement("return new $T($S + attributes)",
+                    IllegalStateException.class, "Cannot build " + type.baseType.rawType.name +
+                            ", some of required attributes are not set: ");
+
+            build.beginControlFlow("if (initBits != 0) {");
+            build.addStatement("throw initializationIncomplete()");
+            build.endControlFlow();
+        }
+
+        if (singleton) {
+            build.addStatement("return canonize(new $T(this))", type.immutableType);
+        } else {
+            build.addStatement("return new $T(this)", type.immutableType);
+        }
+
+        build.complete();
+        pending.complete();
+
+        builder.complete();
+
+        fileService.writeTo(renderer);
+    }
+
+    private void generateFrom(ValueType type, ClassRenderer<?> builder, CompletionDeferrer pending) {
+
+        var from = builder.addMethod(type.builderType, "from", Modifier.PUBLIC)
+                .addParameter(type.superType, "instance");
+
+        int optBits = 0;
+        Map<String, String> commonMethods = new HashMap<>();
+        Map<TypeRef, List<String>> typeToMethods = new HashMap<>();
+
+        for (String name : type.superTypeMethodsNames) {
+            if (!commonMethods.containsKey(name)) {
+                String mask = Integer.toHexString(1 << optBits++);
+
+                commonMethods.put(name, mask);
+            }
+        }
+
+        for (TypeRef typeRef : type.interfaces) {
+            TypeElement t = elements.getTypeElement(typeRef.getTypeName());
+            Objects.requireNonNull(t, typeRef.getTypeName());
+            List<String> methods = new ArrayList<>();
+
+            for (Element e : t.getEnclosedElements()) {
+                String name = e.getSimpleName().toString();
+                if (e.getKind() != ElementKind.METHOD ||
+                    name.equals("identifier") ||
+                    e.getModifiers().contains(Modifier.STATIC)) {
+                    continue;
+                }
+
+                if (!commonMethods.containsKey(name)) {
+                    String mask = Integer.toHexString(1 << optBits++);
+
+                    commonMethods.put(name, mask);
+                }
+
+                methods.add(name);
+            }
+
+            if (!methods.isEmpty()){
+                typeToMethods.put(typeRef, methods);
+            }
+        }
+
+        if (optBits > 0) {
+            from.addStatement("$T bits = 0", floorBitFlagsType(optBits));
+        }
+
+        // - base type
+        // - super type (if it has common methods)
+        // - interfaces
+
+        from.beginControlFlow("if (instance instanceof $T) {",
+                type.baseType.withTypeArguments(Collections.nCopies(
+                        type.typeVars.size(), WildcardTypeRef.none())));
+        from.addStatement("$1T c = ($1T) instance", type.baseType);
+
+        for (ValueAttribute a : type.attributes) {
+            String mask = commonMethods.get(a.name);
+            from.addStatement("$1L(c.$1L())", a.name);
+
+            if (mask != null) {
+                from.addStatement("bits |= 0x$L", mask);
+            }
+        }
+
+        from.endControlFlow();
+
+        if (!type.superTypeMethodsNames.isEmpty()) {
+            from.beginControlFlow("if (instance instanceof $T) {", type.superType);
+            from.addStatement("$1T c = ($1T) instance", type.superType);
+
+            for (String name : type.superTypeMethodsNames) {
+                String mask = commonMethods.get(name);
+                if (mask != null) {
+                    from.beginControlFlow("if ((bits & 0x$L) == 0) {", mask);
+                }
+
+                from.addStatement("$1L(c.$1L())", name);
+
+                if (mask != null) {
+                    from.addStatement("bits |= 0x$L", mask);
+                    from.endControlFlow();
+                }
+            }
+
+            from.endControlFlow();
+        }
+
+        for (var e : typeToMethods.entrySet()) {
+            from.beginControlFlow("if (instance instanceof $T) {", e.getKey());
+            from.addStatement("$1T c = ($1T) instance", e.getKey());
+
+            for (String s : e.getValue()) {
+                String mask = commonMethods.get(s);
+                if (mask != null) {
+                    from.beginControlFlow("if ((bits & 0x$L) == 0) {", mask);
+                }
+
+                from.addStatement("$1L(c.$1L())", s);
+
+                if (mask != null) {
+                    from.addStatement("bits |= 0x$L", mask);
+                    from.endControlFlow();
+                }
+            }
+
+            from.endControlFlow();
+        }
+
+        from.addStatement("return this");
+
+        pending.add(from);
+    }
+
+    private void generateCopyParameters(ValueType type, ValueAttribute a,
+                                        MethodRenderer<?> renderer, String paramName,
+                                        String newValueVar) {
+        renderer.addCode("return ");
+        if (type.flags.contains(ValueType.Flag.SINGLETON)) {
+            renderer.addCode("canonize(");
+        }
+
+        renderer.addCode("new $T(", type.immutableType);
+        if (type.needStubParam) {
+            renderer.addCode("null, ");
+        }
+
+        for (int i = 0, n = type.generated.size(); i < n; i++) {
+            ValueAttribute b = type.generated.get(i);
+
+            String c = i != 0 ? ",$W " : "";
+            String s = qualify(b, paramName);
+
+            if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                if (b.name.equals(a.flagsName)) {
+                    s = newValue.apply(a.flagsName); // update flags
+                } else if (a == b) { // update param
+                    s = newValueVar;
+                }
+            } else if (a == b) {
+                s = newValueVar;
+            }
+
+            renderer.addCode(c + "$L", s);
+        }
+
+        renderer.addCode(')');
+        if (type.flags.contains(ValueType.Flag.SINGLETON)) {
+            renderer.addCode(')');
+        }
+        renderer.addCode(';');
+    }
+
+    private void generateWither(ValueType type, ValueAttribute a,
+                                TopLevelRenderer renderer, CompletionDeferrer pending) {
+
+        TypeRef listElement = unwrap(a.type, LIST);
+
+        TypeRef paramType = a.type;
+        if (listElement != a.type) // Iterable<? extends ParamType>
+            paramType = ParameterizedTypeRef.of(ITERABLE, expandBounds(listElement));
+        if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) // @Nullable ParamType
+            paramType = AnnotatedTypeRef.create(paramType, Nullable.class);
+
+        String name = with.apply(a.name);
+        String paramName = listElement != a.type ? "values" : "value";
+        String localName = qualify(a, paramName);
+        String newValueVar = newValue.apply(a.name);
+        boolean transformed = false;
+
+        var withMethod = renderer.addMethod(type.immutableType, name)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(paramType, paramName);
+
+        if (a.flags.contains(ValueAttribute.Flag.BIT_FLAG)) {
+            // just delegate to with[flagsName] method
+            withMethod.addStatement("return $L($T.mask($L, $L, $L))",
+                    with.apply(a.flagsName()), UTILITY, a.flagsName(), a.flagMask(),
+                    paramName);
+
+            withMethod.complete();
+            return;
+        } else if (listElement != a.type) {
+            transformed = true;
+
+            if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+                withMethod.addStatement("if ($L == $L) return this", localName, paramName);
+
+                if (listElement == BYTE_BUF) {
+                    // implicit null-check in .map()
+                    withMethod.addStatement("$1T $2L = $3L != null ? $4T.stream($3L.spliterator(), false)$B" +
+                                    ".map($5T::copyAsUnpooled)$B.collect($6T.toUnmodifiableList()) : null",
+                            a.type, newValueVar, paramName, StreamSupport.class, UTILITY, Collectors.class);
+                } else {
+                    withMethod.addStatement("$1T $2L = $3L != null ? $4T.copyList($3L) : null",
+                            a.type, newValueVar, paramName, UTILITY);
+
+                }
+
+                // re-compare references, maybe they are both equal to List.of()
+                withMethod.addStatement("if ($L == $L) return this", localName, newValueVar);
+
+                withMethod.addStatement("int $L = $T.mask($L, $L, $L != null)",
+                        newValue.apply(a.flagsName), UTILITY, a.flagsName, a.flagMask, newValueVar);
+
+                var withVarargsMethod = renderer.addMethod(type.immutableType, name)
+                        .addModifiers(Modifier.PUBLIC)
+                        .addParameter(AnnotatedTypeRef.create(listElement, Nullable.class), paramName, true)
+                        .addStatement("if ($L == null && $L == null) return this", localName, paramName);
+
+                if (listElement == BYTE_BUF) {
+                    withVarargsMethod.addStatement("var $2L = $3L != null ? $6T.stream($3L)$B" +
+                                    ".map($4T::copyAsUnpooled)$B.collect($5T.toUnmodifiableList()) : null",
+                            a.type, newValueVar, paramName, UTILITY, Collectors.class, Arrays.class);
+                } else {
+                    withVarargsMethod.addStatement("var $1L = $2L != null ? $3T.of($2L) : null", newValueVar, paramName, LIST);
+                }
+
+                withVarargsMethod.addStatement("if ($L == $L) return this", localName, newValueVar);
+                withVarargsMethod.addStatement("int $L = $T.mask($L, $L, $L != null)",
+                        newValue.apply(a.flagsName), UTILITY, a.flagsName, a.flagMask, newValueVar);
+
+                generateCopyParameters(type, a, withVarargsMethod, paramName, newValueVar);
+
+                pending.add(withVarargsMethod);
+            } else {
+                withMethod.addStatement("$T.requireNonNull($L)", Objects.class, paramName);
+                withMethod.addStatement("if ($L == $L) return this", localName, paramName);
+
+                if (listElement == BYTE_BUF) {
+                    withMethod.addStatement("var $1L = $2T.stream($3L.spliterator(), false)$B" +
+                                    ".map($4T::copyAsUnpooled)$B.collect($5T.toUnmodifiableList())",
+                            newValueVar, StreamSupport.class, paramName, UTILITY, Collectors.class);
+                } else {
+                    withMethod.addStatement("$T $L = $T.copyList($L)", a.type, newValueVar, UTILITY, paramName);
+                }
+
+                withMethod.addStatement("if ($L == $L) return this", localName, newValueVar);
+
+                var withVarargsMethod = renderer.addMethod(type.immutableType, name)
+                        .addModifiers(Modifier.PUBLIC)
+                        .addParameter(listElement, paramName, true)
+                        .addStatement("$T.requireNonNull($L)", Objects.class, paramName);
+
+                if (listElement == BYTE_BUF) {
+                    withVarargsMethod.addStatement("var $1L = $2T.stream($3L)$B.map($4T::copyAsUnpooled)$B.collect($5T.toUnmodifiableList())",
+                            newValueVar, Arrays.class, paramName, UTILITY, Collectors.class);
+                } else {
+                    withVarargsMethod.addStatement("var $L = $T.of($L)", newValueVar, LIST, paramName);
+                }
+
+                withVarargsMethod.addStatement("if ($L == $L) return this", localName, newValueVar);
+
+                generateCopyParameters(type, a, withVarargsMethod, paramName, newValueVar);
+
+                pending.add(withVarargsMethod);
+            }
+        } else if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+            TypeRef unboxed = a.type.safeUnbox();
+
+            if (unboxed instanceof PrimitiveTypeRef) {
+                transformed = true;
+
+                withMethod.addStatement("if ($T.eq(($L & $L) != 0, $L, $L)) return this",
+                        UTILITY, a.flagsName(), a.flagMask(), localName, paramName);
+
+                withMethod.addStatement("$1T $2L = $4L != null ? $4L : $3L",
+                        unboxed, newValueVar, defaultValueFor(unboxed), paramName);
+            } else if (unboxed == BYTE_BUF) {
+                transformed = true;
+
+                withMethod.addStatement("if ($L == $L) return this", localName, paramName);
+                withMethod.addStatement("$1T $2L = $4L != null ? $3T.copyAsUnpooled($4L) : null", BYTE_BUF, newValueVar, UTILITY, paramName);
+            } else if (unboxed == STRING) {
+                withMethod.addStatement("if ($T.equals($L, $L)) return this", Objects.class, localName, paramName);
+            } else  {
+                withMethod.addStatement("if ($L == $L) return this", localName, paramName);
+            }
+
+            withMethod.addStatement("int $L = $T.mask($L, $L, $L != null)",
+                    newValue.apply(a.flagsName()), UTILITY, a.flagsName(), a.flagMask(), paramName);
+        } else if (a.type == PrimitiveTypeRef.DOUBLE) {
+            withMethod.addStatement("if (Double.doubleToLongBits($L) == Double.doubleToLongBits($L)) return this", localName, paramName);
+        } else if (a.type instanceof PrimitiveTypeRef) {
+            withMethod.addStatement("if ($L == $L) return this", localName, paramName);
+        } else {
+            withMethod.addStatement("$T.requireNonNull($L)", Objects.class, paramName);
+
+            if (a.type == STRING) { // Its implementation of the equals method is fast enough
+                withMethod.addStatement("if ($L.equals($L)) return this", localName, paramName);
+            } else {
+                withMethod.addStatement("if ($L == $L) return this", localName, paramName);
+            }
+
+            if (a.type == BYTE_BUF) {
+                transformed = true;
+                withMethod.addStatement("$T $L = $T.copyAsUnpooled($L)", BYTE_BUF, newValueVar, UTILITY, paramName);
+            }
+        }
+
+        if (!transformed) {
+            newValueVar = paramName;
+        }
+
+        generateCopyParameters(type, a, withMethod, paramName, newValueVar);
+        withMethod.complete();
+    }
+
+    private void generateSetter(ValueType type, ValueAttribute a,
+                                ClassRenderer<?> builder, CompletionDeferrer pending) {
+
+        TypeRef listElement = unwrap(a.type, LIST);
+
+        if (!a.flags.contains(ValueAttribute.Flag.BIT_FLAG)) {
+            builder.addField(a.type, a.name, Modifier.PRIVATE).complete();
+        }
+
+        var setter = builder.addMethod(type.builderType, a.name)
+                .addModifiers(Modifier.PUBLIC);
+
+        if (a.flags.contains(ValueAttribute.Flag.BIT_FLAG)) {
+            setter.addParameter(a.type, a.name);
+
+            setter.addStatement("$1L = $4T.mask($1L, $2L, $3L)", a.flagsName, a.flagMask, a.name, UTILITY);
+        } else if (listElement != a.type) {
+            generateListSetters(type, a, setter, builder, pending);
+        } else if (a.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+            setter.addParameter(AnnotatedTypeRef.create(a.type, Nullable.class), a.name);
+
+            setter.addStatement("this.$1L = $1L", a.name);
+            setter.addStatement("$1L = $4T.mask($1L, $2L, $3L != null)", a.flagsName, a.flagMask, a.name, UTILITY);
+        } else if (a.type instanceof PrimitiveTypeRef) {
+            setter.addParameter(a.type, a.name);
+
+            setter.addStatement("this.$1L = $1L", a.name);
+
+            // flags fields is implicitly optional
+            if (!a.flags.contains(ValueAttribute.Flag.BIT_SET)) {
+                setter.addStatement("this.initBits &= ~$L", a.names.initBit);
+            }
+        } else { // reference type
+            setter.addParameter(a.type, a.name);
+
+            if (a.type == BYTE_BUF) {
+                setter.addStatement("this.$1L = $2T.copyAsUnpooled($1L)", a.name, UTILITY);
+            } else {
+                setter.addStatement("this.$1L = $2T.requireNonNull($1L)", a.name, Objects.class);
+            }
+            setter.addStatement("this.initBits &= ~$L", a.names.initBit);
+        }
+
+        setter.addStatement("return this");
+        pending.add(setter);
+    }
+
+    private void generateListSetters(ValueType type, ValueAttribute a, MethodRenderer<?> setter,
+                                     ClassRenderer<?> builder, CompletionDeferrer pending) {
+
+        TypeRef listElement = unwrap(a.type, LIST);
+        TypeRef iterableType = ParameterizedTypeRef.of(ITERABLE, expandBounds(listElement));
+        boolean opt = a.flags.contains(ValueAttribute.Flag.OPTIONAL);
+
+        // add methods
+
+        String localNameSingular = qualify(a, "value");
+        String localName = qualify(a, "values");
+
+        var add = pending.add(builder.addMethod(type.builderType, a.names.add)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(listElement, "value")
+                .addStatement("$T.requireNonNull(value)", Objects.class)
+                .addStatement("if ($1L == null) $1L = new $2T<>()", localNameSingular, ArrayList.class));
+
+        var addv = pending.add(builder.addMethod(type.builderType, a.names.addv)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(listElement, "values", true));
+
+        var addAll = pending.add(builder.addMethod(type.builderType, a.names.addAll)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(iterableType, "values"));
+
+        String copyTransform = listElement == BYTE_BUF ? "$3T::copyAsUnpooled" : "$4T::requireNonNull";
+        addv.addStatement("$1T copy = $2T.stream(values)$B.map(" + copyTransform + ")$B.collect($5T.toList())",
+                a.type, Arrays.class, UTILITY, Objects.class, Collectors.class);
+        addv.beginControlFlow("if ($L == null) {", localName);
+        addv.addStatement("$L = copy", localName);
+        addv.nextControlFlow("} else {");
+        addv.addStatement("$L.addAll(copy)", localName);
+        addv.endControlFlow();
+
+        addAll.addStatement("$1T copy = $2T.stream(values.spliterator(), false)$B.map(" + copyTransform + ")$B.collect($5T.toList())",
+                a.type, StreamSupport.class, UTILITY, Objects.class, Collectors.class);
+        addAll.beginControlFlow("if ($L == null) {", localName);
+        addAll.addStatement("$L = copy", localName);
+        addAll.nextControlFlow("} else {");
+        addAll.addStatement("$L.addAll(copy)", localName);
+        addAll.endControlFlow();
+
+        if (listElement == BYTE_BUF) {
+            add.addStatement("$L.add($L.copyAsUnpooled(value))", localNameSingular, UTILITY);
+        } else {
+            add.addStatement("$L.add(value)", localNameSingular);
+        }
+
+        if (opt) {
+            add.addStatement("$L |= $L", a.flagsName, a.flagMask);
+            addv.addStatement("$L |= $L", a.flagsName, a.flagMask);
+            addAll.addStatement("$L |= $L", a.flagsName, a.flagMask);
+        } else {
+            add.addStatement("$L &= ~$L", type.initBitsName, a.names.initBit);
+            addv.addStatement("$L &= ~$L", type.initBitsName, a.names.initBit);
+            addAll.addStatement("$L &= ~$L", type.initBitsName, a.names.initBit);
+        }
+
+        add.addStatement("return this");
+        addv.addStatement("return this");
+        addAll.addStatement("return this");
+
+        // set method
+
+        String setTransform = listElement == BYTE_BUF ? "$3T::copyAsUnpooled" : "$5T::requireNonNull";
+        String copyCode = "$2T.stream(values.spliterator(), false)$B.map(" + setTransform + ")$B.collect($4T.toList())";
+        if (opt) {
+            setter.addParameter(AnnotatedTypeRef.create(iterableType, Nullable.class), "values")
+                    .beginControlFlow("if (values == null) {")
+                    .addStatement("$L = null", localName)
+                    .addStatement("$L &= ~$L", a.flagsName, a.flagMask)
+                    .addStatement("return this")
+                    .endControlFlow()
+                    .addStatement("$1L = " + copyCode, localName, StreamSupport.class, UTILITY, Collectors.class, Objects.class)
+                    .addStatement("$L |= $L", a.flagsName, a.flagMask);
+        } else {
+            setter.addParameter(iterableType, "values")
+                    .addStatement("$1L = " + copyCode, localName, StreamSupport.class, UTILITY, Collectors.class, Objects.class)
+                    .addStatement("$L &= ~$L", type.initBitsName, a.names.initBit);
+        }
+    }
+
+    private void generateEmpty(ValueType type, TopLevelRenderer renderer) {
+
+        renderer.addField(type.immutableType, "INSTANCE", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                .initializer("new $T()", type.immutableType)
+                .complete();
+
+        renderer.addConstructor(Modifier.PRIVATE).complete();
+
+        renderer.addMethod(type.immutableType, "of", Modifier.PUBLIC, Modifier.STATIC)
+                .addStatement("return INSTANCE")
+                .complete();
+
+        renderer.addMethod(int.class, "identifier")
+                .addAnnotations(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addStatement("return ID")
+                .complete();
+
+        renderer.addMethod(boolean.class, "equals")
+                .addAnnotations(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(Object.class, "o")
+                .addStatement("return this == o || o instanceof $1L && ID == (($1L) o).identifier()",
+                        type.baseType.withTypeArguments(Collections.nCopies(type.typeVars.size(), WildcardTypeRef.none())))
+                .complete();
+
+        renderer.addMethod(int.class, "hashCode")
+                .addAnnotations(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addStatement("return ID")
+                .complete();
+
+        renderer.addMethod(String.class, "toString")
+                .addAnnotations(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addStatement("return \"$L#$L{}\"", type.baseType.rawType.name, type.tlType.id)
+                .complete();
+    }
+
+    // utilities
+
+    private TypeRef expandBounds(TypeRef type) {
+        if (type == STRING || type.safeUnbox() instanceof PrimitiveTypeRef) {
+            return type;
+        }
+        return WildcardTypeRef.subtypeOf(type);
+    }
+
+    private String qualify(ValueAttribute a, String name) {
+        return a.name.equals(name) ? "this." + a.name : a.name;
+    }
+
+    private String bitsCountMethod(int bits) {
+        if (bits < Integer.SIZE) {
+            return "Integer.bitCount";
+        } else if (bits < Long.SIZE) {
+            return "Long.bitCount";
+        } else {
+            throw new IllegalStateException(String.valueOf(bits));
+        }
+    }
+
+    private TypeRef floorBitFlagsType(int bits) {
+        if (bits < Byte.SIZE) {
+            return PrimitiveTypeRef.BYTE;
+        } else if (bits < Short.SIZE) {
+            return PrimitiveTypeRef.SHORT;
+        } else if (bits < Integer.SIZE) {
+            return PrimitiveTypeRef.INT;
+        } else if (bits < Long.SIZE) {
+            return PrimitiveTypeRef.LONG;
+        } else {
+            throw new IllegalStateException(String.valueOf(bits));
+        }
+    }
+
+    private TypeRef unboxOptional(ValueAttribute attribute) {
+        if (attribute.flags.contains(ValueAttribute.Flag.OPTIONAL)) {
+            return attribute.type.safeUnbox();
+        }
+        return attribute.type;
+    }
+
+    private String defaultValueFor(TypeRef type) {
+        if (type == PrimitiveTypeRef.BOOLEAN)
+            return "false";
+        else if (type instanceof PrimitiveTypeRef)
+            return "0";
+        else
+            return "null";
+    }
+
+    static class ValueType {
+        public final ParameterizedTypeRef baseType;
+        public final ParameterizedTypeRef immutableType;
+        public final ParameterizedTypeRef builderType;
+        public final List<TypeVariableRef> typeVars;
+        public final List<TypeVariableRef> typeVarNames;
+        public final List<? extends TypeRef> interfaces;
+
+        public ValueType(ClassRef baseType, List<TypeVariableRef> typeVars, List<? extends TypeRef> interfaces) {
+            typeVarNames = typeVars.stream()
+                    .map(TypeVariableRef::withBounds)
+                    .collect(Collectors.toList());
+
+            this.baseType = ParameterizedTypeRef.of(baseType, typeVarNames);
+            this.typeVars = typeVars;
+            this.interfaces = interfaces;
+
+            immutableType = ParameterizedTypeRef.of(baseType.peer(immutable.apply(baseType.name)), typeVarNames);
+            builderType = ParameterizedTypeRef.of(immutableType.rawType.nested("Builder"), typeVarNames);
+        }
+
+        public boolean needStubParam;
+        public boolean canOmitCopyConstr;
+        public List<ValueAttribute> attributes;
+        public List<ValueAttribute> generated;
+        public EnumSet<ValueType.Flag> flags = EnumSet.noneOf(ValueType.Flag.class);
+        public TlProcessing.Type tlType;
+        public TypeRef superType;
+        public Set<String> superTypeMethodsNames;
+        public int initBitsCount;
+
+        public String initBitsName;
+        public String hashCodeName;
+        public String equalsName;
+
+        enum Flag {
+            SINGLETON, // all fields are optional
+            GENERIC_METHOD,
+        }
+    }
+
+    static TypeRef unwrap(TypeRef type, TypeRef pred) {
+        ParameterizedTypeRef p;
+        return type instanceof ParameterizedTypeRef &&
+                !(p = (ParameterizedTypeRef) type).typeArguments.isEmpty() &&
+                p.rawType.equals(pred)
+                ? p.typeArguments.get(0)
+                : type;
+    }
+
+    static class CompletionDeferrer {
+
+        private final List<CompletableRenderer<?>> pending = new ArrayList<>();
+
+        public <P, T extends CompletableRenderer<P>> T add(T renderer) {
+            pending.add(renderer);
+            return renderer;
+        }
+        public void complete() {
+            pending.forEach(CompletableRenderer::complete);
+            pending.clear();
+        }
+    }
+
+    static class ValueAttribute {
+        public final String name;
+        public final Names names;
+
+        public TypeRef type;
+        public EnumSet<ValueAttribute.Flag> flags = EnumSet.noneOf(ValueAttribute.Flag.class);
+        @Nullable
+        public String flagsName;
+        @Nullable
+        public String flagMask;
+
+        ValueAttribute(String name) {
+            this.name = name;
+
+            names = new Names();
+        }
+
+        public String flagsName() {
+            Objects.requireNonNull(flagsName);
+            return flagsName;
+        }
+
+        public String flagMask() {
+            Objects.requireNonNull(flagMask);
+            return flagMask;
+        }
+
+        enum Flag {
+            BIT_FLAG,
+            BIT_SET,
+            OPTIONAL // all @Nullable fields except bit flags
+        }
+
+        class Names {
+            public final String singular = Depluralizer.instance().apply(name);
+            public final String initBit = Style.initBit.apply(name, Naming.As.SCREMALIZED);
+            public final String add = Style.add.apply(singular);
+            public final String addv = Style.add.apply(name);
+            public final String addAll = Style.addAll.apply(name);
+        }
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/ImmutableGenerator.java
+++ b/parser/src/main/java/telegram4j/tl/generator/ImmutableGenerator.java
@@ -574,7 +574,7 @@ class ImmutableGenerator {
             c = "instance";
         }
 
-        for (ValueAttribute a : type.attributes) {
+        for (ValueAttribute a : type.generated) {
             String mask = commonMethods.get(a.name);
             from.addStatement("$1L($2L.$1L())", a.name, c);
 

--- a/parser/src/main/java/telegram4j/tl/generator/NameDeduplicator.java
+++ b/parser/src/main/java/telegram4j/tl/generator/NameDeduplicator.java
@@ -1,0 +1,31 @@
+package telegram4j.tl.generator;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class NameDeduplicator implements Consumer<String>, Supplier<String> {
+    private final String base;
+
+    private byte counter;
+
+    private NameDeduplicator(String base) {
+        this.base = Objects.requireNonNull(base);
+    }
+
+    public static NameDeduplicator create(String base) {
+        return new NameDeduplicator(base);
+    }
+
+    @Override
+    public void accept(String s) {
+        if ((base + counter).equals(s)) {
+            counter++;
+        }
+    }
+
+    @Override
+    public String get() {
+        return counter == 0 ? base : base + counter;
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/Naming.java
+++ b/parser/src/main/java/telegram4j/tl/generator/Naming.java
@@ -1,0 +1,147 @@
+package telegram4j.tl.generator;
+
+import reactor.util.annotation.Nullable;
+
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+
+public abstract class Naming implements UnaryOperator<String> {
+
+    private static final String NAME_PLACEHOLDER = "*";
+    private static final Pattern NAME_PATTERN = Pattern.compile(Pattern.quote(NAME_PLACEHOLDER));
+
+    @Override
+    public String apply(String input) {
+        return apply(input, As.IDENTICAL);
+    }
+
+    public abstract String apply(String input, As as);
+
+    public enum As {
+        IDENTICAL,
+        SCREMALIZED
+    }
+
+    public static Naming from(String template) {
+        if (template.isEmpty() || template.equals(NAME_PLACEHOLDER)) {
+            return IDENTITY_NAMING;
+        }
+
+        String[] parts = NAME_PATTERN.split(template, 3);
+        Preconditions.requireState(parts.length <= 2, "Template '" + template
+                + "' contains more than one '*' placeholder");
+
+        if (parts.length == 1) {
+            return new ConstantNaming(template);
+        }
+        return new PrefixSuffixNaming(parts[0], parts[1]);
+    }
+
+    public static Naming identity() {
+        return IDENTITY_NAMING;
+    }
+
+    @Nullable
+    public abstract String detect(String identifier);
+
+    private static final Naming IDENTITY_NAMING = new Naming() {
+        @Override
+        public String apply(String input, As as) {
+            switch (as) {
+                case IDENTICAL: return input;
+                case SCREMALIZED: return Strings.screamilize(input);
+                default: throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public String detect(String identifier) {
+            return identifier;
+        }
+
+        @Override
+        public String toString() {
+            return NAME_PLACEHOLDER;
+        }
+    };
+
+    private static class ConstantNaming extends Naming {
+        final String name;
+
+        ConstantNaming(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String apply(String input, As as) {
+            switch (as) {
+                case IDENTICAL: return name;
+                case SCREMALIZED: return Strings.screamilize(name);
+                default: throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public String detect(String identifier) {
+            return identifier.equals(name) ? name : null;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    private static class PrefixSuffixNaming extends Naming {
+        private final String prefix;
+        private final String suffix;
+        private final int minLength;
+
+        PrefixSuffixNaming(String prefix, String suffix) {
+            this.prefix = prefix;
+            this.suffix = suffix;
+            this.minLength = prefix.length() + suffix.length();
+        }
+
+        @Override
+        public String apply(String input, As as) {
+            String result;
+            if (prefix.isEmpty()) {
+                result = input + suffix;
+            } else {
+                String fixedInput = input.isEmpty() ? input : Character.toUpperCase(input.charAt(0)) + input.substring(1);
+                result = prefix + fixedInput + suffix;
+            }
+
+            switch (as) {
+                case IDENTICAL: return result;
+                case SCREMALIZED: return Strings.screamilize(result);
+                default: throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public String detect(String identifier) {
+            if (identifier.length() <= minLength) {
+                return null;
+            }
+
+            boolean prefixMatches = prefix.isEmpty() || identifier.startsWith(prefix) &&
+                    Character.isUpperCase(identifier.charAt(prefix.length()));
+
+            boolean suffixMatches = suffix.isEmpty() || identifier.endsWith(suffix);
+
+            if (!prefixMatches || !suffixMatches) {
+                return null;
+            }
+
+            String detected = identifier.substring(prefix.length(), identifier.length() - suffix.length());
+            return prefix.isEmpty() ? detected : Character.toLowerCase(detected.charAt(0)) + detected.substring(1);
+        }
+
+        @Override
+        public String toString() {
+            return prefix + NAME_PLACEHOLDER + suffix;
+        }
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/Preconditions.java
+++ b/parser/src/main/java/telegram4j/tl/generator/Preconditions.java
@@ -1,0 +1,30 @@
+package telegram4j.tl.generator;
+
+import java.util.function.Supplier;
+
+public class Preconditions {
+
+    public static void requireArgument(boolean state, String text) {
+        if (!state) {
+            throw new IllegalArgumentException(text);
+        }
+    }
+
+    public static void requireArgument(boolean state, Supplier<String> text) {
+        if (!state) {
+            throw new IllegalArgumentException(text.get());
+        }
+    }
+
+    public static void requireState(boolean state, String text) {
+        if (!state) {
+            throw new IllegalStateException(text);
+        }
+    }
+
+    public static void requireState(boolean state, Supplier<String> text) {
+        if (!state) {
+            throw new IllegalStateException(text.get());
+        }
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
@@ -406,7 +406,7 @@ public class SchemaGenerator extends AbstractProcessor {
             }
 
             var identifierMethod = renderer.addMethod(int.class, "identifier")
-                    .addAnnotations(Override.class);
+                    .addAnnotation(Override.class);
             if (isEmptyMethod) {
                 identifierMethod.addModifiers(Modifier.PUBLIC);
             } else {
@@ -420,13 +420,13 @@ public class SchemaGenerator extends AbstractProcessor {
                 emptyObjectsIds.add(method.id);
 
                 renderer.addMethod(int.class, "hashCode")
-                        .addAnnotations(Override.class)
+                        .addAnnotation(Override.class)
                         .addModifiers(Modifier.PUBLIC)
                         .addStatement("return ID")
                         .complete();
 
                 renderer.addMethod(String.class, "toString")
-                        .addAnnotations(Override.class)
+                        .addAnnotation(Override.class)
                         .addModifiers(Modifier.PUBLIC)
                         .addStatement("return \"$L#$L{}\"", renderer.name, method.id)
                         .complete();
@@ -608,7 +608,7 @@ public class SchemaGenerator extends AbstractProcessor {
             }
 
             var identifierMethod = renderer.addMethod(int.class, "identifier")
-                    .addAnnotations(Override.class);
+                    .addAnnotation(Override.class);
             if (isEmptyObject) {
                 identifierMethod.addModifiers(Modifier.PUBLIC);
             } else {
@@ -624,13 +624,13 @@ public class SchemaGenerator extends AbstractProcessor {
                 emptyObjectsIds.add(constructor.id);
 
                 renderer.addMethod(int.class, "hashCode")
-                        .addAnnotations(Override.class)
+                        .addAnnotation(Override.class)
                         .addModifiers(Modifier.PUBLIC)
                         .addStatement("return ID")
                         .complete();
 
                 renderer.addMethod(String.class, "toString")
-                        .addAnnotations(Override.class)
+                        .addAnnotation(Override.class)
                         .addModifiers(Modifier.PUBLIC)
                         .addStatement("return \"$L#$L{}\"", renderer.name, constructor.id)
                         .complete();
@@ -932,7 +932,7 @@ public class SchemaGenerator extends AbstractProcessor {
                         .complete();
 
                 renderer.addMethod(int.class, "identifier")
-                        .addAnnotations(Override.class)
+                        .addAnnotation(Override.class)
                         .addModifiers(Modifier.PUBLIC)
                         .addStatement("return identifier")
                         .complete();
@@ -952,7 +952,7 @@ public class SchemaGenerator extends AbstractProcessor {
                     var commonAttr = renderer.addMethod(paramType, param.formattedName());
 
                     if (param.type.isFlag() && !param.type.isBitFlag()) {
-                        commonAttr.addAnnotations(Nullable.class);
+                        commonAttr.addAnnotation(Nullable.class);
                     }
 
                     commonAttr.complete();
@@ -995,7 +995,7 @@ public class SchemaGenerator extends AbstractProcessor {
             attribute.addStatement("return ($L() & $L) != 0", param.type.flagsName,
                     bitMask.apply(param.formattedName(), Naming.As.SCREMALIZED));
         } else if (param.type.isFlag()) {
-            attribute.addAnnotations(Nullable.class);
+            attribute.addAnnotation(Nullable.class);
         }
 
         attribute.complete();

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
@@ -354,6 +354,7 @@ public class SchemaGenerator extends AbstractProcessor {
 
             boolean generic = method.type.rawType.equals("X");
             if (generic) {
+                // <R, T extends TlMethod<? extends R>>
                 renderer.addTypeVariables(genericResultTypeRef, genericTypeRef.withBounds(wildcardMethodType));
             }
 
@@ -452,7 +453,7 @@ public class SchemaGenerator extends AbstractProcessor {
                 var sizeOfBlock = serializer.createCode().incIndent(2);
 
                 int size = 4;
-                StringJoiner sizes = new StringJoiner(" + ");
+                StringJoiner sizes = new StringJoiner(" +$W ");
                 for (int i = 0, n = method.parameters.size(); i < n; i++) {
                     Parameter param = method.parameters.get(i);
 
@@ -471,7 +472,7 @@ public class SchemaGenerator extends AbstractProcessor {
                         String sizeVar = sizeVariable.apply(param.formattedName());
 
                         sizeOfBlock.addStatement("int $L = " + sizeMethod, sizeVar, param.formattedName());
-                        sizes.add(sizeVar + "$W");
+                        sizes.add(sizeVar);
                     }
 
                     String ser = serializeMethod(param);
@@ -672,7 +673,7 @@ public class SchemaGenerator extends AbstractProcessor {
                 var sizeOfBlock = serializer.createCode().incIndent(2);
 
                 int size = 4;
-                StringJoiner sizes = new StringJoiner(" + ");
+                StringJoiner sizes = new StringJoiner(" +$W ");
                 for (int i = 0, n = constructor.parameters.size(); i < n; i++) {
                     Parameter param = constructor.parameters.get(i);
 
@@ -693,7 +694,7 @@ public class SchemaGenerator extends AbstractProcessor {
                         sizeOfBlock.addStatement("int $L = " + sizeMethod, sizeVar, param.formattedName());
 
                         // TODO: Maybe add an overflow check?
-                        sizes.add(sizeVar + "$W");
+                        sizes.add(sizeVar);
                     }
 
                     String ser = serializeMethod(param);

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
@@ -859,10 +859,13 @@ public class SchemaGenerator extends AbstractProcessor {
                 .filter(e -> !e.flags.contains(ValueAttribute.Flag.BIT_FLAG))
                 .collect(Collectors.toList());
 
-        valType.canOmitCopyConstr = primitivefCount == valType.generated.size();
+        if (primitivefCount == valType.generated.size())
+            valType.flags.add(ValueType.Flag.CAN_OMIT_COPY_CONSTRUCTOR);
         // TODO: don't generate bitset parameter if it has no bit flags
-        valType.canOmitOfMethod = bitSetfCount != 0 && flagsfCount == 0;
-        valType.needStubParam = reffCount > 0;
+        if (bitSetfCount != 0 && flagsfCount == 0)
+            valType.flags.add(ValueType.Flag.CAN_OMIT_OF_METHOD);
+        if (reffCount > 0)
+            valType.flags.add(ValueType.Flag.NEED_STUB_PARAM);
 
         return valType;
     }

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
@@ -842,6 +842,7 @@ public class SchemaGenerator extends AbstractProcessor {
         if (types.size() > 1) {
             valType.superTypeMethodsNames = types.stream()
                     .flatMap(e -> e.parameters.stream())
+                    .filter(e -> !e.type.isBitFlag())
                     .filter(p -> types.stream()
                             .allMatch(t -> t.parameters.contains(p)))
                     .map(Parameter::formattedName)

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
@@ -756,6 +756,14 @@ public class SchemaGenerator extends AbstractProcessor {
 
         valType.canOmitCopyConstr = primitiveFieldsCount == valType.generated.size();
         valType.needStubParam = refFieldsCount > 0;
+
+        valType.usedBits = new HashMap<>();
+        for (ImmutableGenerator.ValueAttribute a : valType.attributes) {
+            if (a.flags.contains(ImmutableGenerator.ValueAttribute.Flag.BIT_FLAG)) {
+                valType.usedBits.computeIfAbsent(a.flagsName, k -> new BitSet()).set(a.flagPos);
+            }
+        }
+
         return valType;
     }
 

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGenerator.java
@@ -708,6 +708,7 @@ public class SchemaGenerator extends AbstractProcessor {
             if (p.type.isFlag()) {
                 valAttr.flagsName = p.type.flagsName();
                 valAttr.flagMask = bitMask.apply(valAttr.name, Naming.As.SCREMALIZED);
+                valAttr.flagPos = p.type.flagPos();
 
                 if (p.type.isBitFlag()) {
                     valAttr.flags.add(ImmutableGenerator.ValueAttribute.Flag.BIT_FLAG);

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGeneratorConsts.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGeneratorConsts.java
@@ -1,46 +1,62 @@
 package telegram4j.tl.generator;
 
-import com.squareup.javapoet.*;
+import io.netty.buffer.ByteBuf;
 import telegram4j.tl.api.TlMethod;
+import telegram4j.tl.generator.renderer.*;
 
-import javax.lang.model.element.Modifier;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-public final class SchemaGeneratorConsts {
+final class SchemaGeneratorConsts {
 
     private SchemaGeneratorConsts() {
     }
 
-    public static final int LAYER = 143;
+    static final int LAYER = 143;
 
     // channelFull has two flags fields
-    public static final Pattern FLAG_PATTERN = Pattern.compile("^(\\w+)\\.(\\d+)\\?(.+)$");
-    public static final Pattern VECTOR_PATTERN = Pattern.compile("^[vV]ector<%?([\\w.<>]+)>$");
+    static final Pattern FLAG_PATTERN = Pattern.compile("^(\\w+)\\.(\\d+)\\?(.+)$");
+    static final Pattern VECTOR_PATTERN = Pattern.compile("^[vV]ector<%?([\\w.<>]+)>$");
     // excluded from generation
-    public static final Set<String> ignoredTypes = Set.of("True", "Null", "HttpWait");
-    // list of types whose ids will be in TlPrimitives
-    public static final Set<String> primitiveTypes = Set.of(
+    static final Set<String> ignoredTypes = Set.of("True", "Null", "HttpWait");
+    // list of types whose ids will be in TlInfo
+    static final Set<String> primitiveTypes = Set.of(
             "Bool", "Vector t", "JSONValue", "JSONObjectValue");
 
-    public static final String METHOD_PACKAGE_PREFIX = "request";
-    public static final String TEMPLATE_PACKAGE_INFO = "package-info.template";
-    public static final String SUPERTYPES_DATA = "supertypes.json";
-    public static final String BASE_PACKAGE = "telegram4j.tl";
-    public static final String INDENT = "\t";
+    static final String METHOD_PACKAGE_PREFIX = "request";
+    static final String TEMPLATE_PACKAGE_INFO = "package-info.template";
+    static final String SUPERTYPES_DATA = "supertypes.json";
+    static final String BASE_PACKAGE = "telegram4j.tl";
 
-    public static final TypeVariableName genericTypeRef = TypeVariableName.get("T");
-    public static final TypeVariableName genericResultTypeRef = TypeVariableName.get("R");
-    public static final TypeName wildcardMethodType = ParameterizedTypeName.get(
-            ClassName.get(TlMethod.class), WildcardTypeName.subtypeOf(genericResultTypeRef));
-    public static final TypeName wildcardUnboundedMethodType = ParameterizedTypeName.get(
-            ClassName.get(TlMethod.class), WildcardTypeName.subtypeOf(TypeName.OBJECT));
+    static final TypeVariableRef genericTypeRef = TypeVariableRef.of("T");
+    static final TypeVariableRef genericResultTypeRef = TypeVariableRef.of("R");
+    // <R, T extends TlMethod<? extends R>>
+    static final TypeRef wildcardMethodType = ParameterizedTypeRef.of(
+            TlMethod.class, WildcardTypeRef.subtypeOf(genericResultTypeRef));
 
-    public static final MethodSpec privateConstructor = MethodSpec.constructorBuilder()
-            .addModifiers(Modifier.PRIVATE)
-            .build();
-
-    public static final List<NameTransformer> namingExceptions = List.of(
+    static final List<NameTransformer> namingExceptions = List.of(
             NameTransformer.create("messages.StickerSet", "messages.StickerSetWithDocuments"));
+
+    // some interned types
+
+    static final ClassRef LIST = ClassRef.of(List.class);
+    static final ClassRef ITERABLE = ClassRef.of(Iterable.class);
+    static final ClassRef STRING = ClassRef.of(String.class);
+    static final ClassRef BYTE_BUF = ClassRef.of(ByteBuf.class);
+
+    // names style
+
+    static class Style {
+        static final Naming sizeVariable = Naming.from("*Size");
+        static final Naming bitMask = Naming.from("*Mask");
+        static final Naming bitPos = Naming.from("*Pos");
+
+        static final Naming immutable = Naming.from("Immutable*");
+        static final Naming add = Naming.from("add*");
+        static final Naming addAll = Naming.from("addAll*");
+        static final Naming with = Naming.from("with*");
+        static final Naming newValue = Naming.from("new*Value");
+        static final Naming initBit = Naming.from("initBit*");
+    }
 }

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGeneratorConsts.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGeneratorConsts.java
@@ -35,9 +35,6 @@ final class SchemaGeneratorConsts {
     static final TypeRef wildcardMethodType = ParameterizedTypeRef.of(
             TlMethod.class, WildcardTypeRef.subtypeOf(genericResultTypeRef));
 
-    static final List<NameTransformer> namingExceptions = List.of(
-            NameTransformer.create("messages.StickerSet", "messages.StickerSetWithDocuments"));
-
     // some interned types
 
     static final ClassRef LIST = ClassRef.of(List.class);

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGeneratorConsts.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGeneratorConsts.java
@@ -56,6 +56,7 @@ final class SchemaGeneratorConsts {
         static final Naming add = Naming.from("add*");
         static final Naming addAll = Naming.from("addAll*");
         static final Naming with = Naming.from("with*");
+        static final Naming set = Naming.from("set*");
         static final Naming newValue = Naming.from("new*Value");
         static final Naming initBit = Naming.from("initBit*");
     }

--- a/parser/src/main/java/telegram4j/tl/generator/SchemaGeneratorConsts.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SchemaGeneratorConsts.java
@@ -15,7 +15,6 @@ final class SchemaGeneratorConsts {
 
     public static final int LAYER = 144;
 
-    // channelFull has two flags fields
     static final Pattern FLAG_PATTERN = Pattern.compile("^(\\w+)\\.(\\d+)\\?(.+)$");
     static final Pattern VECTOR_PATTERN = Pattern.compile("^[vV]ector<%?([\\w.<>]+)>$");
     // excluded from generation
@@ -31,7 +30,7 @@ final class SchemaGeneratorConsts {
 
     static final TypeVariableRef genericTypeRef = TypeVariableRef.of("T");
     static final TypeVariableRef genericResultTypeRef = TypeVariableRef.of("R");
-    // <R, T extends TlMethod<? extends R>>
+    // <TlMethod<? extends R>>
     static final TypeRef wildcardMethodType = ParameterizedTypeRef.of(
             TlMethod.class, WildcardTypeRef.subtypeOf(genericResultTypeRef));
 

--- a/parser/src/main/java/telegram4j/tl/generator/SourceNames.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SourceNames.java
@@ -34,12 +34,7 @@ public final class SourceNames {
     }
 
     public static String formatFieldName(String name, @Nullable String type) {
-        name = camelize(name);
-
-        char f = name.charAt(0);
-        if (Character.isUpperCase(f)) {
-            name = Character.toLowerCase(f) + name.substring(1);
-        }
+        name = camelize(name, true);
 
         // TODO, replace
         if (!SourceVersion.isName(name)) {
@@ -84,5 +79,19 @@ public final class SourceNames {
             return qualifiedName.substring(0, dot);
         }
         return "";
+    }
+
+    public static String escape(char c) {
+        switch (c) {
+            case '\b': return "\\b";
+            case '\f': return "\\f";
+            case '\n': return "\\n";
+            case '\r': return "\\r";
+            case '\t': return "\\t";
+            case '\'': return "\\'";
+            case '\"': return "\\\"";
+            case '\\': return "\\\\";
+            default: return c >= ' ' && c <= '~' ? String.valueOf(c) : String.format("\\u%04x", (int) c);
+        }
     }
 }

--- a/parser/src/main/java/telegram4j/tl/generator/SourceNames.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SourceNames.java
@@ -12,6 +12,11 @@ public final class SourceNames {
     private SourceNames() {
     }
 
+    @Nullable
+    public static String jacksonName(String name) {
+        return name.indexOf('_') == -1 ? null : name;
+    }
+
     public static String normalizeName(String type) {
         type = applyNamingExceptions(type);
 

--- a/parser/src/main/java/telegram4j/tl/generator/SourceNames.java
+++ b/parser/src/main/java/telegram4j/tl/generator/SourceNames.java
@@ -4,7 +4,6 @@ import reactor.util.annotation.Nullable;
 
 import javax.lang.model.SourceVersion;
 
-import static telegram4j.tl.generator.SchemaGeneratorConsts.namingExceptions;
 import static telegram4j.tl.generator.Strings.camelize;
 
 public final class SourceNames {
@@ -18,8 +17,6 @@ public final class SourceNames {
     }
 
     public static String normalizeName(String type) {
-        type = applyNamingExceptions(type);
-
         int dotIdx = type.lastIndexOf('.');
         if (dotIdx != -1) {
             type = type.substring(dotIdx + 1);
@@ -68,14 +65,6 @@ public final class SourceNames {
         }
 
         return name;
-    }
-
-    public static String applyNamingExceptions(String s) {
-        String l = s;
-        for (NameTransformer t : namingExceptions) {
-            l = t.apply(l);
-        }
-        return l;
     }
 
     public static String parentPackageName(String qualifiedName) {

--- a/parser/src/main/java/telegram4j/tl/generator/Strings.java
+++ b/parser/src/main/java/telegram4j/tl/generator/Strings.java
@@ -25,11 +25,11 @@ public final class Strings {
         return builder.toString();
     }
 
-    static String screamilize(String type) {
-        StringBuilder buf = new StringBuilder(type.length());
-        for (int i = 0; i < type.length(); i++) {
-            char p = i - 1 != -1 ? type.charAt(i - 1) : Character.MIN_VALUE;
-            char c = type.charAt(i);
+    static String screamilize(CharSequence cs) {
+        StringBuilder buf = new StringBuilder(cs.length());
+        for (int i = 0; i < cs.length(); i++) {
+            char p = i - 1 != -1 ? cs.charAt(i - 1) : Character.MIN_VALUE;
+            char c = cs.charAt(i);
 
             if (Character.isLetter(c) && Character.isLetter(p) &&
                 Character.isLowerCase(p) && Character.isUpperCase(c)) {
@@ -37,8 +37,8 @@ public final class Strings {
             }
 
             if (c == '.' || c == '-' || c == '_' || Character.isWhitespace(c) &&
-                    Character.isLetterOrDigit(p) && i + 1 < type.length() &&
-                    Character.isLetterOrDigit(type.charAt(i + 1))) {
+                    Character.isLetterOrDigit(p) && i + 1 < cs.length() &&
+                    Character.isLetterOrDigit(cs.charAt(i + 1))) {
 
                 buf.append('_');
             } else {

--- a/parser/src/main/java/telegram4j/tl/generator/Strings.java
+++ b/parser/src/main/java/telegram4j/tl/generator/Strings.java
@@ -1,19 +1,22 @@
 package telegram4j.tl.generator;
 
-final class Strings {
+public final class Strings {
 
     private Strings() {}
 
-    static String camelize(String type) {
-        if (!type.contains("_") && !type.contains(".")) {
-            return type;
-        }
+    static String camelize(String str) {
+        return camelize(str, false);
+    }
 
-        StringBuilder builder = new StringBuilder(type.length());
-        for (int i = 0; i < type.length(); i++) {
-            char c = type.charAt(i);
-            if (c == '_' || c == '.') {
-                char n = Character.toUpperCase(type.charAt(++i));
+    static String camelize(String str, boolean firstAsLower) {
+        StringBuilder builder = new StringBuilder(str.length());
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            if (i == 0 && firstAsLower) {
+                char n = Character.toLowerCase(str.charAt(i));
+                builder.append(n);
+            } else if ((c == '_' || c == '.') && ++i < str.length()) {
+                char n = Character.toUpperCase(str.charAt(i));
                 builder.append(n);
             } else {
                 builder.append(c);
@@ -29,7 +32,7 @@ final class Strings {
             char c = type.charAt(i);
 
             if (Character.isLetter(c) && Character.isLetter(p) &&
-                    Character.isLowerCase(p) && Character.isUpperCase(c)) {
+                Character.isLowerCase(p) && Character.isUpperCase(c)) {
                 buf.append('_');
             }
 

--- a/parser/src/main/java/telegram4j/tl/generator/TlProcessing.java
+++ b/parser/src/main/java/telegram4j/tl/generator/TlProcessing.java
@@ -1,6 +1,7 @@
 package telegram4j.tl.generator;
 
 import reactor.util.annotation.Nullable;
+import telegram4j.tl.generator.renderer.TypeRef;
 import telegram4j.tl.parser.TlTrees;
 import telegram4j.tl.parser.TlTrees.Type.Kind;
 
@@ -45,10 +46,10 @@ public class TlProcessing {
         public final String name;
         @Nullable
         public final String packagePrefix;
-        public final TypeMirror superType;
+        public final TypeRef superType;
 
         private Configuration(String basePackageName, String name,
-                              @Nullable String packagePrefix, @Nullable TypeMirror superType) {
+                              @Nullable String packagePrefix, @Nullable TypeRef superType) {
             this.basePackageName = basePackageName;
             this.name = name;
             this.packagePrefix = packagePrefix;
@@ -83,9 +84,10 @@ public class TlProcessing {
                         .map(Configuration::<String>cast)
                         .orElse(null);
 
-                TypeMirror superType = Optional.ofNullable(config.get("superType"))
+                TypeRef superType = Optional.ofNullable(config.get("superType"))
                         .map(AnnotationValue::getValue)
                         .map(Configuration::<TypeMirror>cast)
+                        .map(TypeRef::from)
                         .orElse(null);
 
                 configs[i] = new Configuration(basePackageName, name, packagePrefix, superType);
@@ -211,6 +213,10 @@ public class TlProcessing {
 
         public boolean isFlag() {
             return flagPos != -1;
+        }
+
+        public boolean isBitFlag() {
+            return isFlag() && innerType().rawType.equals("true");
         }
 
         public boolean isVector() {

--- a/parser/src/main/java/telegram4j/tl/generator/TlProcessing.java
+++ b/parser/src/main/java/telegram4j/tl/generator/TlProcessing.java
@@ -159,6 +159,19 @@ public class TlProcessing {
             String packageName = parsePackageName(config, rawType, method);
             return new TypeNameBase(packageName, rawType);
         }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (this == o) return true;
+            if (!(o instanceof TypeNameBase)) return false;
+            TypeNameBase that = (TypeNameBase) o;
+            return packageName.equals(that.packageName) && rawType.equals(that.rawType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(packageName, rawType);
+        }
     }
 
     public static class TypeName extends TypeNameBase {
@@ -222,6 +235,20 @@ public class TlProcessing {
         public boolean isVector() {
             return innerType != null && flagPos == -1;
         }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            TypeName typeName = (TypeName) o;
+            return Objects.equals(innerType, typeName.innerType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), innerType);
+        }
     }
 
     public static class Parameter {
@@ -239,27 +266,24 @@ public class TlProcessing {
             if (formattedName != null) {
                 return formattedName;
             }
-            return formattedName = SourceNames.formatFieldName(name, correctType0());
+            return formattedName = SourceNames.formatFieldName(name, rawType0());
         }
 
-        private String correctType0() {
+        private String rawType0() {
             return (type.innerType != null && type.isFlag() ? type.innerType : type).rawType;
         }
 
         @Override
-        public int hashCode() {
-            return Objects.hash(name, correctType0());
+        public boolean equals(@Nullable Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Parameter parameter = (Parameter) o;
+            return name.equals(parameter.name) && type.equals(parameter.type);
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Parameter that = (Parameter) o;
-
-            return name.equals(that.name) &&
-                    type.isFlag() == that.type.isFlag() &&
-                    correctType0().equals(that.correctType0());
+        public int hashCode() {
+            return Objects.hash(name, type);
         }
     }
 }

--- a/parser/src/main/java/telegram4j/tl/generator/ValueAttribute.java
+++ b/parser/src/main/java/telegram4j/tl/generator/ValueAttribute.java
@@ -1,0 +1,65 @@
+package telegram4j.tl.generator;
+
+import reactor.util.annotation.Nullable;
+import telegram4j.tl.generator.renderer.TypeRef;
+
+import java.util.EnumSet;
+import java.util.Objects;
+
+import static telegram4j.tl.generator.SchemaGeneratorConsts.*;
+
+class ValueAttribute {
+    public final String name;
+
+    public TypeRef type;
+    public EnumSet<Flag> flags = EnumSet.noneOf(ValueAttribute.Flag.class);
+    @Nullable
+    public String flagsName;
+    @Nullable
+    public String flagMask;
+    public int flagPos = -1;
+    @Nullable
+    public String jsonName;
+
+    @Nullable
+    private Names names;
+
+    ValueAttribute(String name) {
+        this.name = name;
+
+        names = new Names();
+    }
+
+    public Names names() {
+        if (names == null) {
+            names = new Names();
+        }
+        return names;
+    }
+
+    public String flagsName() {
+        Objects.requireNonNull(flagsName);
+        return flagsName;
+    }
+
+    public String flagMask() {
+        Objects.requireNonNull(flagMask);
+        return flagMask;
+    }
+
+    class Names {
+        public final String singular = Depluralizer.instance().apply(name);
+        public final String initBit = Style.initBit.apply(name, Naming.As.SCREMALIZED);
+        public final String add = Style.add.apply(singular);
+        public final String addv = Style.add.apply(name);
+        public final String set = Style.set.apply(name);
+        public final String addAll = Style.addAll.apply(name);
+    }
+
+    enum Flag {
+        BIT_FLAG,
+        BIT_SET,
+        OPTIONAL // all @Nullable fields except bit flags
+
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/ValueAttribute.java
+++ b/parser/src/main/java/telegram4j/tl/generator/ValueAttribute.java
@@ -58,8 +58,7 @@ class ValueAttribute {
 
     enum Flag {
         BIT_FLAG,
-        BIT_SET,
-        OPTIONAL // all @Nullable fields except bit flags
-
+        BIT_SET, // implicitly optional attribute
+        OPTIONAL
     }
 }

--- a/parser/src/main/java/telegram4j/tl/generator/ValueAttribute.java
+++ b/parser/src/main/java/telegram4j/tl/generator/ValueAttribute.java
@@ -26,8 +26,6 @@ class ValueAttribute {
 
     ValueAttribute(String name) {
         this.name = name;
-
-        names = new Names();
     }
 
     public Names names() {

--- a/parser/src/main/java/telegram4j/tl/generator/ValueType.java
+++ b/parser/src/main/java/telegram4j/tl/generator/ValueType.java
@@ -42,7 +42,7 @@ class ValueType {
     public List<ValueAttribute> attributes;
     public List<ValueAttribute> generated; // list without boolean bit flags
     public EnumSet<Flag> flags = EnumSet.noneOf(ValueType.Flag.class);
-    public TlProcessing.Type tlType;
+    public String identifier;
     public TypeRef superType;
     public Set<String> superTypeMethodsNames;
     public int initBitsCount;

--- a/parser/src/main/java/telegram4j/tl/generator/ValueType.java
+++ b/parser/src/main/java/telegram4j/tl/generator/ValueType.java
@@ -1,0 +1,58 @@
+package telegram4j.tl.generator;
+
+
+import telegram4j.tl.generator.renderer.ClassRef;
+import telegram4j.tl.generator.renderer.ParameterizedTypeRef;
+import telegram4j.tl.generator.renderer.TypeRef;
+import telegram4j.tl.generator.renderer.TypeVariableRef;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static telegram4j.tl.generator.SchemaGeneratorConsts.Style.immutable;
+
+class ValueType {
+    public final ParameterizedTypeRef baseType;
+    public final ParameterizedTypeRef immutableType;
+    public final ParameterizedTypeRef builderType;
+    public final ParameterizedTypeRef jsonType;
+    public final List<TypeVariableRef> typeVars;
+    public final List<TypeVariableRef> typeVarNames;
+    public final List<? extends TypeRef> interfaces;
+
+    public ValueType(ClassRef baseType, List<TypeVariableRef> typeVars, List<? extends TypeRef> interfaces) {
+        typeVarNames = typeVars.stream()
+                .map(TypeVariableRef::withBounds)
+                .collect(Collectors.toList());
+
+        this.baseType = ParameterizedTypeRef.of(baseType, typeVarNames);
+        this.typeVars = typeVars;
+        this.interfaces = interfaces;
+
+        immutableType = ParameterizedTypeRef.of(baseType.peer(immutable.apply(baseType.name)), typeVarNames);
+        builderType = ParameterizedTypeRef.of(immutableType.rawType.nested("Builder"), typeVarNames);
+        jsonType = ParameterizedTypeRef.of(immutableType.rawType.nested("Json"), typeVarNames);
+    }
+
+    public Map<String, BitSet> usedBits;
+
+    public boolean needStubParam;
+    public boolean canOmitCopyConstr;
+    public boolean canOmitOfMethod;
+    public List<ValueAttribute> attributes;
+    public List<ValueAttribute> generated; // list without boolean bit flags
+    public EnumSet<Flag> flags = EnumSet.noneOf(ValueType.Flag.class);
+    public TlProcessing.Type tlType;
+    public TypeRef superType;
+    public Set<String> superTypeMethodsNames;
+    public int initBitsCount;
+
+    public String initBitsName;
+    public String hashCodeName;
+    public String equalsName;
+
+    enum Flag {
+        SINGLETON, // all fields are optional
+        GENERIC_METHOD,
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/ValueType.java
+++ b/parser/src/main/java/telegram4j/tl/generator/ValueType.java
@@ -15,10 +15,23 @@ class ValueType {
     public final ParameterizedTypeRef baseType;
     public final ParameterizedTypeRef immutableType;
     public final ParameterizedTypeRef builderType;
-    public final ParameterizedTypeRef jsonType;
     public final List<TypeVariableRef> typeVars;
     public final List<TypeVariableRef> typeVarNames;
     public final List<? extends TypeRef> interfaces;
+
+    public Map<String, BitSet> usedBits;
+
+    public List<ValueAttribute> attributes;
+    public List<ValueAttribute> generated; // list without boolean bit flags
+    public EnumSet<Flag> flags = EnumSet.noneOf(ValueType.Flag.class);
+    public String identifier;
+    public TypeRef superType;
+    public Set<String> superTypeMethodsNames;
+    public short initBitsCount;
+
+    public String initBitsName;
+    public String hashCodeName;
+    public String equalsName;
 
     public ValueType(ClassRef baseType, List<TypeVariableRef> typeVars, List<? extends TypeRef> interfaces) {
         typeVarNames = typeVars.stream()
@@ -31,28 +44,12 @@ class ValueType {
 
         immutableType = ParameterizedTypeRef.of(baseType.peer(immutable.apply(baseType.name)), typeVarNames);
         builderType = ParameterizedTypeRef.of(immutableType.rawType.nested("Builder"), typeVarNames);
-        jsonType = ParameterizedTypeRef.of(immutableType.rawType.nested("Json"), typeVarNames);
     }
-
-    public Map<String, BitSet> usedBits;
-
-    public boolean needStubParam;
-    public boolean canOmitCopyConstr;
-    public boolean canOmitOfMethod;
-    public List<ValueAttribute> attributes;
-    public List<ValueAttribute> generated; // list without boolean bit flags
-    public EnumSet<Flag> flags = EnumSet.noneOf(ValueType.Flag.class);
-    public String identifier;
-    public TypeRef superType;
-    public Set<String> superTypeMethodsNames;
-    public int initBitsCount;
-
-    public String initBitsName;
-    public String hashCodeName;
-    public String equalsName;
 
     enum Flag {
         SINGLETON, // all fields are optional
-        GENERIC_METHOD,
+        NEED_STUB_PARAM,
+        CAN_OMIT_COPY_CONSTRUCTOR,
+        CAN_OMIT_OF_METHOD
     }
 }

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/AnnotatedRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/AnnotatedRenderer.java
@@ -1,0 +1,13 @@
+package telegram4j.tl.generator.renderer;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+
+public interface AnnotatedRenderer<P> extends CompletableRenderer<P> {
+
+    AnnotatedRenderer<P> addAnnotation(AnnotationRenderer renderer);
+
+    AnnotatedRenderer<P> addAnnotations(Type... annotations);
+
+    AnnotatedRenderer<P> addAnnotations(Collection<? extends Type> annotations);
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/AnnotatedRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/AnnotatedRenderer.java
@@ -1,5 +1,6 @@
 package telegram4j.tl.generator.renderer;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Collection;
 
@@ -7,7 +8,7 @@ public interface AnnotatedRenderer<P> extends CompletableRenderer<P> {
 
     AnnotatedRenderer<P> addAnnotation(AnnotationRenderer renderer);
 
-    AnnotatedRenderer<P> addAnnotations(Type... annotations);
+    AnnotatedRenderer<P> addAnnotation(Class<? extends Annotation> annotation);
 
-    AnnotatedRenderer<P> addAnnotations(Collection<? extends Type> annotations);
+    AnnotatedRenderer<P> addAnnotations(Iterable<Class<? extends Annotation>> annotations);
 }

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/AnnotatedTypeRef.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/AnnotatedTypeRef.java
@@ -1,0 +1,90 @@
+package telegram4j.tl.generator.renderer;
+
+import reactor.util.annotation.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class AnnotatedTypeRef implements TypeRef {
+
+    public final TypeRef type;
+    public final List<ClassRef> annotations;
+
+    private AnnotatedTypeRef(TypeRef type, List<ClassRef> annotations) {
+        this.type = Objects.requireNonNull(type);
+        this.annotations = Objects.requireNonNull(annotations);
+    }
+
+    public List<ClassRef> annotations() {
+        return annotations;
+    }
+
+    public static AnnotatedTypeRef create(Type type) {
+        return create(type, List.of());
+    }
+
+    @SafeVarargs
+    public static AnnotatedTypeRef create(Type type, Class<? extends Annotation>... annotations) {
+        return create(type, Arrays.asList(annotations));
+    }
+
+    public static AnnotatedTypeRef create(Type type, Collection<Class<? extends Annotation>> annotations) {
+        Objects.requireNonNull(type);
+        if (type instanceof AnnotatedTypeRef) {
+            return (AnnotatedTypeRef) type;
+        }
+
+        return new AnnotatedTypeRef(TypeRef.of(type), annotations.stream()
+                .map(ClassRef::of)
+                .collect(Collectors.toUnmodifiableList()));
+    }
+
+    @SafeVarargs
+    public final AnnotatedTypeRef withAnnotations(Class<? extends Annotation>... annotations) {
+        return new AnnotatedTypeRef(type, Arrays.stream(annotations)
+                .map(ClassRef::of)
+                .collect(Collectors.toUnmodifiableList()));
+    }
+
+    @Override
+    public String getTypeName() {
+        StringBuilder ann = new StringBuilder();
+        for (ClassRef annotation : annotations) {
+            ann.append('@');
+            ann.append(annotation.getTypeName());
+            ann.append(' ');
+        }
+        ann.append(type.getTypeName());
+        return ann.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AnnotatedTypeRef that = (AnnotatedTypeRef) o;
+        return type.equals(that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return type.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ann = new StringBuilder();
+        for (ClassRef annotation : annotations) {
+            ann.append('@');
+            ann.append(annotation);
+            ann.append(' ');
+        }
+        ann.append(type);
+        return ann.toString();
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/AnnotationRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/AnnotationRenderer.java
@@ -1,0 +1,263 @@
+package telegram4j.tl.generator.renderer;
+
+public class AnnotationRenderer implements CompletableRenderer<CharSequence> {
+    private static final Stage BEGIN = new Stage(0, "BEGIN");
+    private static final Stage VALUE_ATTRIBUTE = new Stage(-1, "VALUE_ATTRIBUTE");
+
+    private final BaseClassRenderer<?> parent;
+    private final CharSink out;
+
+    private Stage stage = BEGIN;
+
+    AnnotationRenderer(ClassRef type, BaseClassRenderer<?> parent, CharSink out) {
+        this.parent = parent;
+        this.out = out;
+
+        out.append('@');
+        parent.appendType(out, type);
+    }
+
+    @Override
+    public Stage stage() {
+        return stage;
+    }
+
+    private void appendName(CharSequence name) {
+        RenderUtils.requireStage(stage, BEGIN, Stage.COMPLETE);
+        if (stage != BEGIN) {
+            parent.formatCode(out, ",$W ");
+        } else {
+            stage = Stage.PROCESSING;
+
+            out.append('(');
+        }
+
+        out.append(name);
+        out.append(" = ");
+
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, Enum<?> value) {
+        appendName(name);
+        parent.appendType(out, ClassRef.of(value.getDeclaringClass()));
+        out.append('.');
+        out.append(value.name());
+        return this;
+    }
+
+
+    public AnnotationRenderer addAttribute(CharSequence name, ClassRef value) {
+        appendName(name);
+        parent.appendType(out, value);
+        out.append(".class");
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, Class<?> value) {
+        return addAttribute(name, ClassRef.of(value));
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, boolean value) {
+        appendName(name);
+        out.append(String.valueOf(value));
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, byte value) {
+        appendName(name);
+        out.append(String.valueOf(value));
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, short value) {
+        appendName(name);
+        out.append(String.valueOf(value));
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, long value) {
+        appendName(name);
+        out.append(String.valueOf(value));
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, float value) {
+        appendName(name);
+        out.append(String.valueOf(value));
+        out.append('f');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, double value) {
+        appendName(name);
+        out.append(String.valueOf(value));
+        out.append('d');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, int value) {
+        appendName(name);
+        out.append(String.valueOf(value));
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, char value) {
+        appendName(name);
+        out.append('\'');
+        out.append(value);
+        out.append('\'');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, CharSequence value) {
+        appendName(name);
+        out.append('\"');
+        out.append(value);
+        out.append('\"');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence name, CharSequence value, Object... args) {
+        appendName(name);
+        parent.formatCode(out, value, args);
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(Enum<?> value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append('(');
+        parent.appendType(out, ClassRef.of(value.getDeclaringClass()));
+        out.append('.');
+        out.append(value.name());
+        out.append(')');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(Class<?> value) {
+        return addAttribute(ClassRef.of(value));
+    }
+
+    public AnnotationRenderer addAttribute(ClassRef value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append('(');
+        parent.appendType(out, value);
+        out.append(".class)");
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(boolean value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append('(');
+        out.append(String.valueOf(value));
+        out.append(')');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(byte value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append('(');
+        out.append(String.valueOf(value));
+        out.append(')');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(short value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append('(');
+        out.append(String.valueOf(value));
+        out.append(')');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(long value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append('(');
+        out.append(String.valueOf(value));
+        out.append(')');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(float value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append('(');
+        out.append(String.valueOf(value));
+        out.append("f)");
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(double value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append('(');
+        out.append(String.valueOf(value));
+        out.append("d)");
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(int value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append('(');
+        out.append(String.valueOf(value));
+        out.append(')');
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(char value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append("('");
+        out.append(value);
+        out.append("')");
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence value) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+
+        out.append("(\"");
+        out.append(value);
+        out.append("\")");
+        return this;
+    }
+
+    public AnnotationRenderer addAttribute(CharSequence value, Object... args) {
+        RenderUtils.requireStage(stage, BEGIN);
+        stage = VALUE_ATTRIBUTE;
+        out.append('(');
+        parent.formatCode(out, value, args);
+        out.append(')');
+        return this;
+    }
+
+    @Override
+    public CharSequence complete() {
+        if (stage != Stage.COMPLETE) {
+            if (stage == Stage.PROCESSING) {
+                out.append(')');
+            }
+
+            out.ln();
+            stage = Stage.COMPLETE;
+        }
+        return out.asStringBuilder();
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ArrayRef.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ArrayRef.java
@@ -1,0 +1,54 @@
+package telegram4j.tl.generator.renderer;
+
+import telegram4j.tl.generator.Preconditions;
+
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.ArrayType;
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ArrayRef implements TypeRef {
+    public final TypeRef component;
+    public final short dimensions;
+
+    private ArrayRef(TypeRef component, short dimensions) {
+        this.component = component;
+        this.dimensions = dimensions;
+    }
+
+    public static ArrayRef of(Type component, short dimensions) {
+        if (component instanceof ArrayRef) {
+            ArrayRef c = (ArrayRef) component;
+
+            dimensions = (short) Math.addExact(c.dimensions, dimensions);
+            component = c.component;
+        }
+
+        Preconditions.requireArgument(dimensions >= 1 && dimensions <= 255, "Dimension must be between [1, 255]");
+        return new ArrayRef(TypeRef.of(component), dimensions);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ArrayRef arrayRef = (ArrayRef) o;
+        return dimensions == arrayRef.dimensions && component.equals(arrayRef.component);
+    }
+
+    @Override
+    public int hashCode() {
+        return component.hashCode() ^ dimensions;
+    }
+
+    @Override
+    public String getTypeName() {
+        return component.getTypeName() + "[]".repeat(dimensions);
+    }
+
+    @Override
+    public String toString() {
+        return component + "[]".repeat(dimensions);
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/BaseClassRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/BaseClassRenderer.java
@@ -4,6 +4,7 @@ import telegram4j.tl.generator.Preconditions;
 import telegram4j.tl.generator.SourceNames;
 
 import javax.lang.model.element.Modifier;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.*;
 
@@ -81,6 +82,8 @@ public abstract class BaseClassRenderer<P> implements CompletableRenderer<P> {
                 }
             } else if (stage == SUPER_TYPE) { // optional
                 stage = required;
+
+                out.incIndent().append(" {")/*.ln()*/;
             } else if (stage == INTERFACES) { // optional
                 stage = required;
 
@@ -236,7 +239,7 @@ public abstract class BaseClassRenderer<P> implements CompletableRenderer<P> {
 
     protected abstract void appendType(CharSink out, TypeRef type);
 
-    private void appendStringLiteral(CharSink out, Object o) {
+    protected void appendStringLiteral(CharSink out, Object o) {
         if (o == null) {
             out.append("null");
             return;
@@ -277,6 +280,10 @@ public abstract class BaseClassRenderer<P> implements CompletableRenderer<P> {
 
     public CodeRenderer<CharSequence> createCode() {
         return new CodeRendererImpl(this, new CharSink(out.autoIndent, out.lineWrap));
+    }
+
+    public AnnotationRenderer createAnnotation(Class<? extends Annotation> type) {
+        return new AnnotationRenderer(ClassRef.of(type), this, new CharSink(out.autoIndent, out.lineWrap));
     }
 
     // writers
@@ -323,6 +330,15 @@ public abstract class BaseClassRenderer<P> implements CompletableRenderer<P> {
 
             appendTypeVariable(out, type);
         }
+        return this;
+    }
+
+    public BaseClassRenderer<P> addAnnotation(AnnotationRenderer renderer) {
+        if (stage != ANNOTATIONS) {
+            requireStage(BEGIN, ANNOTATIONS);
+            completeStage(ANNOTATIONS);
+        }
+        out.append(renderer.complete());
         return this;
     }
 

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/BaseClassRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/BaseClassRenderer.java
@@ -1,0 +1,576 @@
+package telegram4j.tl.generator.renderer;
+
+import telegram4j.tl.generator.Preconditions;
+import telegram4j.tl.generator.SourceNames;
+
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Type;
+import java.util.*;
+
+import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.*;
+
+public abstract class BaseClassRenderer<P> implements CompletableRenderer<P> {
+    protected static final Stage BEGIN = new Stage(-2, "BEGIN"),
+            SUPER_TYPE = new Stage(2, "SUPER_TYPE"),
+            INTERFACES = new Stage(3, "INTERFACES"),
+            CONSTANTS = new Stage(4, "CONSTANTS");
+
+    public final ClassRef name;
+    public final ClassRenderer.Kind kind;
+
+    protected final CharSink out;
+
+    protected CompletableRenderer.Stage stage = BEGIN;
+    protected Deque<CompletableRenderer<?>> pending = new LinkedList<>();
+    protected CompletableRenderer<?> prev;
+
+    protected BaseClassRenderer(ClassRef name, ClassRenderer.Kind kind, CharSink out) {
+        this.name = name;
+        this.kind = kind;
+        this.out = out;
+    }
+
+    protected void complete(BaseCompletableRenderer<?> comp) {
+        if (!(prev instanceof SeparableRenderer) ||
+            ((SeparableRenderer<?>) prev).separate(comp)) {
+            out.ln();
+        }
+
+        prev = comp;
+        out.appendRaw(comp.out);
+    }
+
+    protected void completePending() {
+        CompletableRenderer<?> curr, prev = this.prev;
+        while ((curr = pending.pollLast()) != null) {
+            if (curr.stage() != COMPLETE && (!(curr instanceof SeparableRenderer) ||
+                ((SeparableRenderer<?>) curr).separate(prev))) {
+                out.ln();
+            }
+
+            curr.complete();
+            prev = curr;
+        }
+    }
+
+    protected void completeStage(Stage required) {
+        do {
+            // [ separate (only in nested classes) ]
+            // [ annotations ]
+            // [ modifiers ] [keyword & name] <[ type variables ]> [ super type] [ interfaces ]
+            // [ processing ]
+            if (stage == BEGIN) {
+                stage = ANNOTATIONS;
+                separate0();
+            } else if (stage == ANNOTATIONS || stage == MODIFIERS) {
+                stage = required;
+
+                out.append(kind.asKeyword());
+                out.append(' ');
+                out.append(name.name);
+                if (required == PROCESSING) {
+                    out.incIndent().append(" {")/*.ln()*/;
+                }
+            } else if (stage == TYPE_VARIABLES) { // optional
+                stage = required;
+
+                out.append('>');
+
+                if (required == PROCESSING) {
+                    out.incIndent().append(" {")/*.ln()*/;
+                }
+            } else if (stage == SUPER_TYPE) { // optional
+                stage = required;
+            } else if (stage == INTERFACES) { // optional
+                stage = required;
+
+                out.incIndent().append(" {")/*.ln()*/;
+            } else if (stage == CONSTANTS) {
+                stage = PROCESSING;
+
+                out.append(';').ln();
+            }
+        } while (stage != required);
+    }
+
+    protected <T extends CompletableRenderer<?>> T addPending(T child) {
+        pending.addFirst(child);
+        return child;
+    }
+
+    // stage processing
+
+    protected void requireStage(Stage req) {
+        RenderUtils.requireStage(stage, req);
+    }
+
+    protected void requireStage(Stage min, Stage max) {
+        RenderUtils.requireStage(stage, min, max);
+    }
+
+    protected void formatCode(CharSink out, CharSequence s) {
+        char c;
+        for (int i = 0, n = s.length(); i < n; i++) {
+            c = s.charAt(i);
+            if (c == '$' && i + 1 < n) {
+                c = s.charAt(++i);
+
+                switch (c) {
+                    case 'W': // line wrapping (soft)
+                        out.lw();
+                        break;
+                    case 'B': // force
+                        out.lb();
+                        break;
+                    default:
+                        out.append(c);
+                }
+            } else {
+                out.append(c);
+            }
+        }
+    }
+
+    protected void formatCode(CharSink out, CharSequence s, Object... args) {
+        int relativeIdx = 0;
+        char c, d;
+        for (int i = 0, n = s.length(); i < n; i++) {
+            c = s.charAt(i);
+            if (c == '$' && i + 1 < n) {
+                c = s.charAt(++i);
+                if (c == '$') { // $$
+                    out.append(c);
+                    continue;
+                }
+
+                if (c == 'W') { // line wrapping (soft)
+                    out.lw();
+                    continue;
+                } else if (c == 'B') { // force
+                    out.lb();
+                    continue;
+                }
+
+                int pos;
+                int endPos = i;
+                if (c >= '0' && c <= '9') { // indexed arg
+                    do {
+                        Preconditions.requireArgument(endPos < s.length(), "Unexpected end of format: '" + s + "'");
+                        d = s.charAt(endPos++);
+                    } while (d >= '0' && d <= '9');
+
+                    endPos--;
+                    c = s.charAt(endPos);
+                    pos = Integer.parseInt(s, i, endPos, 10) - 1; // 0-based
+                } else {
+                    pos = relativeIdx++;
+                }
+
+                Preconditions.requireArgument(isFormatControl(c), "Unexpected format token: '" + c + "' at position: " + endPos);
+                Preconditions.requireArgument(pos < args.length, "Missing format argument #" + pos + ", format specifier: '" + s + "'");
+
+                Object o = args[pos];
+                switch (c) {
+                    case 'L':
+                        out.append(o);
+                        break;
+                    case 'S':
+                        appendStringLiteral(out, o);
+                        break;
+                    case 'T':
+                        Objects.requireNonNull(o);
+                        Preconditions.requireArgument(o instanceof Type, () -> "Argument #" + pos + " is not a type: " + o.getClass());
+
+                        appendType(out, TypeRef.of((Type) o));
+                        break;
+                    default: throw new IllegalArgumentException();
+                }
+
+                i = endPos;
+            } else {
+                out.append(c);
+            }
+        }
+    }
+
+    protected void appendTypeVariable(CharSink out, TypeVariableRef type) {
+        out.append(type.name);
+        for (int i = 0, n = type.bounds.size(); i < n; i++) {
+            TypeRef bound = type.bounds.get(i);
+
+            if (i == 0) {
+                out.append(" extends ");
+            } else {
+                out.append(" & ");
+            }
+            appendType(out, bound);
+        }
+    }
+
+    protected void appendModifiers(CharSink out, Iterable<Modifier> modifiers) {
+        for (Modifier modifier : modifiers) {
+            out.append(modifier).append(' ');
+        }
+    }
+
+    protected void appendModifiers(CharSink out, Modifier... modifiers) {
+        for (Modifier modifier : modifiers) {
+            out.append(modifier).append(' ');
+        }
+    }
+
+    protected void appendAnnotations(CharSink out, boolean inline, Collection<? extends Type> annotations) {
+        for (Type annotation : annotations) {
+            out.append('@');
+            appendType(out, TypeRef.of(annotation));
+
+            if (inline) {
+                out.append(' ');
+            } else {
+                out.ln();
+            }
+        }
+    }
+
+    protected abstract void appendType(CharSink out, TypeRef type, boolean vararg);
+
+    protected abstract void appendType(CharSink out, TypeRef type);
+
+    private void appendStringLiteral(CharSink out, Object o) {
+        if (o == null) {
+            out.append("null");
+            return;
+        }
+        if (o instanceof Character) {
+            out.append('\'').append(SourceNames.escape((char) o)).append('\'');
+            return;
+        }
+
+        String s = o.toString();
+
+        out.append('"');
+        for (int i = 0, n = s.length(); i < n; i++) {
+            char c = s.charAt(i);
+            if (c == '\'') {
+                out.append(c);
+            } else {
+                out.append(SourceNames.escape(c));
+            }
+        }
+        out.append('"');
+    }
+
+    private boolean isFormatControl(char c) {
+        switch (c) {
+            case 'L':
+            case 'S':
+            case 'T': return true;
+            default: return false;
+        }
+    }
+
+    // public api
+
+    public abstract BaseClassRenderer<P> addStaticImports(String... staticImports);
+
+    public abstract BaseClassRenderer<P> addStaticImport(String staticImport);
+
+    public CodeRenderer<CharSequence> createCode() {
+        return new CodeRendererImpl(this, new CharSink(out.autoIndent, out.lineWrap));
+    }
+
+    // writers
+
+    public BaseClassRenderer<P> addTypeVariables(TypeVariableRef first, TypeVariableRef... rest) {
+        if (stage != TYPE_VARIABLES) {
+            requireStage(BEGIN, TYPE_VARIABLES);
+            completeStage(TYPE_VARIABLES);
+
+            out.append('<');
+        } else {
+            out.append(", ").lw();
+        }
+
+        appendTypeVariable(out, first);
+        for (TypeVariableRef t : rest) {
+            out.append(", ").lw();
+            appendTypeVariable(out, t);
+        }
+        return this;
+    }
+
+    public BaseClassRenderer<P> addTypeVariables(Collection<TypeVariableRef> types) {
+        if (types.isEmpty()) {
+            return this;
+        }
+
+        if (stage != TYPE_VARIABLES) {
+            requireStage(BEGIN, TYPE_VARIABLES);
+            completeStage(TYPE_VARIABLES);
+
+            out.append('<');
+        } else {
+            out.append(", ").lw();
+        }
+
+        boolean first = true;
+        for (TypeVariableRef type : types) {
+            if (first) {
+                first = false;
+            } else {
+                out.append(", ").lw();
+            }
+
+            appendTypeVariable(out, type);
+        }
+        return this;
+    }
+
+    public BaseClassRenderer<P> addAnnotations(Type... annotations) {
+        return addAnnotations(false, Arrays.asList(annotations));
+    }
+
+    public BaseClassRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+        return addAnnotations(false, annotations);
+    }
+
+    public BaseClassRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
+        if (stage != ANNOTATIONS) {
+            requireStage(BEGIN, ANNOTATIONS);
+            completeStage(ANNOTATIONS);
+        }
+        appendAnnotations(out, inline, annotations);
+        return this;
+    }
+
+    public BaseClassRenderer<P> addModifiers(Modifier... modifiers) {
+        if (stage != MODIFIERS) {
+            requireStage(BEGIN, MODIFIERS);
+            if (stage == BEGIN) { // TODO
+                separate0();
+            }
+            stage = MODIFIERS;
+        }
+        appendModifiers(out, modifiers);
+        return this;
+    }
+
+    public BaseClassRenderer<P> addSuperType(Type type) {
+        Preconditions.requireState(kind == ClassRenderer.Kind.CLASS, "Class extending is not allowed in " + kind);
+        requireStage(BEGIN, TYPE_VARIABLES);
+        completeStage(SUPER_TYPE);
+
+        out.append(" extends ");
+        appendType(out, TypeRef.of(type));
+        return this;
+    }
+
+    public BaseClassRenderer<P> addInterface(Type type) {
+        Preconditions.requireState(kind != ClassRenderer.Kind.ANNOTATION, "Interface implementing is not allowed in " + kind);
+        if (stage != INTERFACES) {
+            requireStage(BEGIN, SUPER_TYPE);
+            completeStage(INTERFACES);
+
+            if (kind == ClassRenderer.Kind.CLASS || kind == ClassRenderer.Kind.ENUM) {
+                out.append(" implements ");
+            } else {
+                out.append(" extends ");
+            }
+        } else {
+            out.append(", ").lw();
+        }
+
+        appendType(out, TypeRef.of(type));
+        return this;
+    }
+
+    public BaseClassRenderer<P> addInterfaces(List<? extends Type> types) {
+        Preconditions.requireState(kind != ClassRenderer.Kind.ANNOTATION, "Interface implementing is not allowed in " + kind);
+        if (types.isEmpty()) {
+            return this; // no way to handle
+        }
+
+        if (stage != INTERFACES) {
+            requireStage(BEGIN, SUPER_TYPE);
+            completeStage(INTERFACES);
+
+            if (kind == ClassRenderer.Kind.CLASS || kind == ClassRenderer.Kind.ENUM) {
+                out.append(" implements ");
+            } else {
+                out.append(" extends ");
+            }
+        } else {
+            out.append(", ").lw();
+        }
+
+        appendType(out, TypeRef.of(types.get(0)));
+        for (int i = 1, n = types.size(); i < n; i++) {
+            TypeRef value = TypeRef.of(types.get(i));
+
+            out.append(", ").lw();
+            appendType(out, value);
+        }
+        return this;
+    }
+
+    public BaseClassRenderer<P> addInterfaces(Type first, Type... rest) {
+        Preconditions.requireState(kind != ClassRenderer.Kind.ANNOTATION, "Interface implementing is not allowed in " + kind);
+        if (stage != INTERFACES) {
+            requireStage(BEGIN, SUPER_TYPE);
+            completeStage(INTERFACES);
+
+            if (kind == ClassRenderer.Kind.CLASS || kind == ClassRenderer.Kind.ENUM) {
+                out.append(" implements ");
+            } else {
+                out.append(" extends ");
+            }
+        } else {
+            out.append(", ").lw();
+        }
+
+        appendType(out, TypeRef.of(first));
+        for (Type value : rest) {
+            TypeRef type = TypeRef.of(value);
+
+            out.append(", ").lw();
+            appendType(out, type);
+        }
+        return this;
+    }
+
+    public BaseClassRenderer<P> addAttribute(Type type, String name) {
+        Preconditions.requireState(kind == ClassRenderer.Kind.ANNOTATION, "Annotation attributes is not allowed in " + kind);
+        if (stage != PROCESSING) {
+            requireStage(BEGIN, PROCESSING);
+            completeStage(PROCESSING);
+        }
+
+        appendType(out, TypeRef.of(type));
+        out.append(' ');
+        out.append(name);
+        out.append("();").ln(2);
+        return this;
+    }
+
+    public BaseClassRenderer<P> addAttribute(Type type, String name, CharSequence format, Object... args) {
+        Preconditions.requireState(kind == ClassRenderer.Kind.ANNOTATION, "Annotation attributes is not allowed in " + kind);
+        if (stage != PROCESSING) {
+            requireStage(BEGIN, PROCESSING);
+            completeStage(PROCESSING);
+        }
+
+        appendType(out, TypeRef.of(type));
+        out.append(' ');
+        out.append(name);
+        out.append("() default ");
+        formatCode(out, format, args);
+        out.append(';').ln(2);
+
+        return this;
+    }
+
+    public BaseClassRenderer<P> addConstant(CharSequence name, CharSequence format, Object... args) {
+        Preconditions.requireState(kind == ClassRenderer.Kind.ENUM, "Enum constants is not allowed in " + kind);
+        if (stage != CONSTANTS) {
+            requireStage(BEGIN, PROCESSING);
+            completeStage(CONSTANTS);
+
+            out.ln(2);
+        } else {
+            out.append(',').ln(2);
+        }
+
+        out.append(name);
+        out.append('(');
+        formatCode(out, format, args);
+        out.append(')');
+
+        return this;
+    }
+
+    public BaseClassRenderer<P> addConstant(CharSequence name) {
+        Preconditions.requireState(kind == ClassRenderer.Kind.ENUM, "Enum constants is not allowed in " + kind);
+        if (stage != CONSTANTS) {
+            requireStage(BEGIN, PROCESSING);
+            completeStage(CONSTANTS);
+
+            out.ln(2);
+        } else {
+            out.append(',').ln(2);
+        }
+
+        out.append(name);
+        return this;
+    }
+
+    public abstract InitializerRenderer<? extends BaseClassRenderer<P>> addStaticInitializer();
+
+    public abstract InitializerRenderer<? extends BaseClassRenderer<P>> addInitializer();
+
+    public FieldRenderer<? extends BaseClassRenderer<P>> addField(Type type, String name) {
+        if (stage != PROCESSING) {
+            requireStage(BEGIN, PROCESSING);
+            completeStage(PROCESSING);
+        }
+        return addPending(new FieldRenderer<>(this, TypeRef.of(type), name));
+    }
+
+    public FieldRenderer<? extends BaseClassRenderer<P>> addField(Type type, String name, Modifier... modifiers) {
+        return addField(type, name)
+                .addModifiers(modifiers);
+    }
+
+    public ExecutableRenderer<? extends BaseClassRenderer<P>> addConstructor() {
+        Preconditions.requireState(kind == ClassRenderer.Kind.CLASS || kind == ClassRenderer.Kind.ENUM,
+                "Constructors is not allowed in " + kind);
+        if (stage != PROCESSING) {
+            requireStage(BEGIN, PROCESSING);
+            completeStage(PROCESSING);
+        }
+        return addPending(new ExecutableRenderer<>(this, name.name));
+    }
+
+    public ExecutableRenderer<? extends BaseClassRenderer<P>> addConstructor(Modifier... modifiers) {
+        return addConstructor()
+                .addModifiers(modifiers);
+    }
+
+    public MethodRenderer<? extends BaseClassRenderer<P>> addMethod(Type returnType, String name) {
+        Preconditions.requireState(kind != ClassRenderer.Kind.ANNOTATION, "Methods is not allowed in " + kind);
+        if (stage != PROCESSING) {
+            requireStage(BEGIN, PROCESSING);
+            completeStage(PROCESSING);
+        }
+        return addPending(new MethodRenderer<>(this, name, TypeRef.of(returnType)));
+    }
+
+    public MethodRenderer<? extends BaseClassRenderer<P>> addMethod(Type returnType, String name, Modifier... modifiers) {
+        return addMethod(returnType, name)
+                .addModifiers(modifiers);
+    }
+
+    protected void complete0() {
+        if (stage == BEGIN || stage == ANNOTATIONS || stage == MODIFIERS) { // empty class
+            if (stage == BEGIN) {
+                separate0();
+            }
+
+            out.append(kind.asKeyword());
+            out.append(' ');
+            out.append(name.name);
+            out.append(" {}").ln();
+        } else if (stage == PROCESSING) {
+            out.decIndent();
+            out.lno().append('}').ln();
+        } else if (stage == INTERFACES || stage == SUPER_TYPE) {
+            out.append(" {}").ln();
+        }
+    }
+
+    protected void separate0() {} // only for nested class renderers
+
+    @Override
+    public Stage stage() {
+        return stage;
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/BaseClassRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/BaseClassRenderer.java
@@ -341,12 +341,12 @@ public abstract class BaseClassRenderer<P>
     }
 
     @Override
-    public BaseClassRenderer<P> addAnnotations(Type... annotations) {
-        return addAnnotations(Arrays.asList(annotations));
+    public BaseClassRenderer<P> addAnnotation(Class<? extends Annotation> annotation) {
+        return addAnnotations(List.of(annotation));
     }
 
     @Override
-    public BaseClassRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+    public BaseClassRenderer<P> addAnnotations(Iterable<Class<? extends Annotation>> annotations) {
         if (stage != ANNOTATIONS) {
             requireStage(BEGIN, ANNOTATIONS);
             completeStage(ANNOTATIONS);

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/BaseClassRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/BaseClassRenderer.java
@@ -10,7 +10,8 @@ import java.util.*;
 
 import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.*;
 
-public abstract class BaseClassRenderer<P> implements CompletableRenderer<P> {
+public abstract class BaseClassRenderer<P>
+        implements CompletableRenderer<P>, AnnotatedRenderer<P> {
     protected static final Stage BEGIN = new Stage(-2, "BEGIN"),
             SUPER_TYPE = new Stage(2, "SUPER_TYPE"),
             INTERFACES = new Stage(3, "INTERFACES"),
@@ -222,16 +223,12 @@ public abstract class BaseClassRenderer<P> implements CompletableRenderer<P> {
         }
     }
 
-    protected void appendAnnotations(CharSink out, boolean inline, Collection<? extends Type> annotations) {
+    protected void appendAnnotations(CharSink out, Iterable<? extends Type> annotations) {
         for (Type annotation : annotations) {
             out.append('@');
             appendType(out, TypeRef.of(annotation));
 
-            if (inline) {
-                out.append(' ');
-            } else {
-                out.ln();
-            }
+            out.ln();
         }
     }
 
@@ -333,6 +330,7 @@ public abstract class BaseClassRenderer<P> implements CompletableRenderer<P> {
         return this;
     }
 
+    @Override
     public BaseClassRenderer<P> addAnnotation(AnnotationRenderer renderer) {
         if (stage != ANNOTATIONS) {
             requireStage(BEGIN, ANNOTATIONS);
@@ -342,20 +340,18 @@ public abstract class BaseClassRenderer<P> implements CompletableRenderer<P> {
         return this;
     }
 
+    @Override
     public BaseClassRenderer<P> addAnnotations(Type... annotations) {
-        return addAnnotations(false, Arrays.asList(annotations));
+        return addAnnotations(Arrays.asList(annotations));
     }
 
+    @Override
     public BaseClassRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
-        return addAnnotations(false, annotations);
-    }
-
-    public BaseClassRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
         if (stage != ANNOTATIONS) {
             requireStage(BEGIN, ANNOTATIONS);
             completeStage(ANNOTATIONS);
         }
-        appendAnnotations(out, inline, annotations);
+        appendAnnotations(out, annotations);
         return this;
     }
 

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/BaseCompletableRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/BaseCompletableRenderer.java
@@ -1,0 +1,31 @@
+package telegram4j.tl.generator.renderer;
+
+abstract class BaseCompletableRenderer<P extends BaseClassRenderer<?>> implements CompletableRenderer<P> {
+    protected final P parent;
+    protected final CharSink out;
+
+    protected Stage stage;
+
+    protected BaseCompletableRenderer(P parent, Stage stage) {
+        this.parent = parent;
+        this.out = parent.out.createChild();
+        this.stage = stage;
+    }
+
+    @Override
+    public Stage stage() {
+        return stage;
+    }
+
+    @Override
+    public P complete() {
+        if (stage != Stage.COMPLETE) {
+            complete0();
+            parent.complete(this);
+            stage = Stage.COMPLETE;
+        }
+        return parent;
+    }
+
+    protected abstract void complete0();
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/BaseCompletableRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/BaseCompletableRenderer.java
@@ -8,8 +8,9 @@ abstract class BaseCompletableRenderer<P extends BaseClassRenderer<?>> implement
 
     protected BaseCompletableRenderer(P parent, Stage stage) {
         this.parent = parent;
-        this.out = parent.out.createChild();
         this.stage = stage;
+
+        out = parent.out.createChild();
     }
 
     @Override

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/CharSink.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/CharSink.java
@@ -92,13 +92,11 @@ public class CharSink {
 
         return this;
     }
-    // optional new line
 
     public CharSink lno() {
         if (!lastIsLn) {
             ln();
         }
-
         return this;
     }
 

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/CharSink.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/CharSink.java
@@ -1,0 +1,177 @@
+package telegram4j.tl.generator.renderer;
+
+public class CharSink {
+    public static final int LINE_WRAP_INDENT = 2;
+
+    public final String autoIndent;
+    public final StringBuilder buf = new StringBuilder();
+    public final int lineWrap;
+
+    protected int column; // 0-based
+    private int indentLevel;
+    private boolean indent;
+    private boolean lastIsLn;
+
+    // child constr
+    private CharSink(CharSink parent) {
+        this.autoIndent = parent.autoIndent;
+        this.lineWrap = parent.lineWrap;
+
+        this.column = 0;
+        this.indentLevel = parent.indentLevel;
+        this.indent = true;
+        this.lastIsLn = true;
+    }
+
+    public CharSink(String autoIndent, int lineWrap) {
+        this.autoIndent = autoIndent;
+        this.lineWrap = lineWrap;
+    }
+
+    private void updateLocation(int columnAdd) {
+        column += columnAdd;
+        lastIsLn = buf.charAt(buf.length() - 1) == '\n';
+        if (lastIsLn) {
+            column = 0;
+
+            if (indentLevel != 0) {
+                indent = true;
+            }
+        }
+    }
+
+    private void appendIndent() {
+        if (indent) {
+            String str = autoIndent.repeat(indentLevel);
+            buf.append(str);
+            column = str.length();
+            indent = false;
+        }
+    }
+
+    public CharSink incIndent() {
+        return incIndent(1);
+    }
+
+    public int indentLevel() {
+        return indentLevel;
+    }
+
+    public CharSink incIndent(int count) {
+        indentLevel += count;
+        return this;
+    }
+
+    public CharSink decIndent() {
+        return decIndent(1);
+    }
+
+    public CharSink decIndent(int count) {
+        indentLevel -= count;
+        return this;
+    }
+
+    public CharSink ln(int count) {
+        buf.append("\n".repeat(count));
+        column = 0;
+        lastIsLn = true;
+        if (indentLevel != 0) {
+            indent = true;
+        }
+
+        return this;
+    }
+
+    public CharSink ln() {
+        buf.append('\n');
+        column = 0;
+        lastIsLn = true;
+        if (indentLevel != 0) {
+            indent = true;
+        }
+
+        return this;
+    }
+    // optional new line
+
+    public CharSink lno() {
+        if (!lastIsLn) {
+            ln();
+        }
+
+        return this;
+    }
+
+    public CharSink lb() {
+        indentLevel += LINE_WRAP_INDENT;
+        ln();
+        appendIndent();
+        indentLevel -= LINE_WRAP_INDENT;
+        return this;
+    }
+
+    public CharSink lw() {
+        if (column >= lineWrap) {
+            lb();
+        }
+        return this;
+    }
+
+    public CharSink append(Object object) {
+        String str = String.valueOf(object);
+        if (str.isEmpty()) {
+            return this;
+        }
+
+        appendIndent();
+        buf.append(str);
+        updateLocation(str.length());
+        return this;
+    }
+
+    public CharSink append(char c) {
+        appendIndent();
+        buf.append(c);
+        updateLocation(1);
+        return this;
+    }
+
+    public CharSink append(CharSequence str, int start, int end) {
+        if (end - start == 0) {
+            return this;
+        }
+
+        appendIndent();
+        buf.append(str, start, end);
+        updateLocation(end - start);
+        return this;
+    }
+
+    public CharSink append(CharSequence str) {
+        if (str.length() == 0) {
+            return this;
+        }
+
+        appendIndent();
+        buf.append(str);
+        updateLocation(str.length());
+        return this;
+    }
+
+    public StringBuilder asStringBuilder() {
+        return buf;
+    }
+
+    public CharSink createChild() {
+        return new CharSink(this);
+    }
+
+    public CharSink appendRaw(CharSink other) {
+        buf.append(other.buf);
+        column += other.buf.length();
+        lastIsLn = buf.charAt(buf.length() - 1) == '\n';
+
+        indent = other.indent;
+        return this;
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRef.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRef.java
@@ -1,0 +1,205 @@
+package telegram4j.tl.generator.renderer;
+
+import reactor.util.annotation.Nullable;
+import telegram4j.tl.generator.Preconditions;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.SimpleElementVisitor9;
+
+public class ClassRef implements TypeRef {
+    public static final ClassRef BOOLEAN = create("Boolean");
+    public static final ClassRef BYTE = create("Byte");
+    public static final ClassRef CHARACTER = create("Character");
+    public static final ClassRef DOUBLE = create("Double");
+    public static final ClassRef FLOAT = create("Float");
+    public static final ClassRef INTEGER = create("Integer");
+    public static final ClassRef LONG = create("Long");
+    public static final ClassRef SHORT = create("Short");
+    public static final ClassRef VOID = create("Void");
+
+    public static final ClassRef OBJECT = create("Object");
+
+    public final String packageName;
+    public final String name;
+    @Nullable
+    public final ClassRef enclosing;
+
+    private ClassRef(String packageName, String name, @Nullable ClassRef enclosing) {
+        this.packageName = packageName;
+        this.name = name;
+        this.enclosing = enclosing;
+    }
+
+    private static ClassRef create(String name) {
+        return new ClassRef( "java.lang", name, null);
+    }
+
+    public static ClassRef of(Class<?> klass) {
+        Preconditions.requireArgument(!klass.isPrimitive(), "Primitive types can not be represented as a ClassRef");
+        Preconditions.requireArgument(!klass.isArray(), "Array types can not be represented as a ClassRef");
+
+        StringBuilder anonymousSuffix = new StringBuilder();
+        int lastDollar;
+        while (klass.isAnonymousClass()) {
+            lastDollar = klass.getName().lastIndexOf('$');
+            anonymousSuffix.insert(0, klass.getName().substring(lastDollar));
+            klass = klass.getEnclosingClass();
+        }
+
+        String name = klass.getSimpleName() + anonymousSuffix;
+        if (klass.getEnclosingClass() == null) {
+            int lastDot = klass.getName().lastIndexOf('.');
+            String packageName = lastDot != -1 ? klass.getName().substring(0, lastDot) : "";
+            return of(packageName, name);
+        }
+
+        return of(klass.getEnclosingClass()).nested(name);
+    }
+
+    public static ClassRef from(TypeElement typeElement) {
+        String simpleName = typeElement.getSimpleName().toString();
+
+        class ClassRefVisitor extends SimpleElementVisitor9<ClassRef, Void> {
+            @Override
+            public ClassRef visitPackage(PackageElement packageElement, Void p) {
+                return new ClassRef(packageElement.getQualifiedName().toString(), simpleName, null);
+            }
+
+            @Override
+            public ClassRef visitType(TypeElement enclosingClass, Void p) {
+                return from(enclosingClass).nested(simpleName);
+            }
+
+            @Override
+            public ClassRef defaultAction(Element enclosingElement, Void p) {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        return typeElement.getEnclosingElement().accept(new ClassRefVisitor(), null);
+    }
+
+    public static ClassRef of(String packageName, String name) {
+        if (packageName.equals("java.lang")) {
+            switch (name) {
+                case "Boolean": return BOOLEAN;
+                case "Byte": return BYTE;
+                case "Character": return CHARACTER;
+                case "Double": return DOUBLE;
+                case "Float": return FLOAT;
+                case "Integer": return INTEGER;
+                case "Long": return LONG;
+                case "Short": return SHORT;
+                case "Void": return VOID;
+            }
+        }
+        return new ClassRef(packageName, name, null);
+    }
+
+    public static ClassRef of(String packageName, String first, String... rest) {
+        if (rest.length == 0) {
+            return of(packageName, first);
+        }
+
+        ClassRef type = new ClassRef(packageName, first, null);
+        for (String name : rest) {
+            type = type.nested(name);
+        }
+        return type;
+    }
+
+    @Override
+    public TypeRef safeUnbox() {
+        if (!isBoxedPrimitive()) {
+            return this;
+        }
+        return unbox();
+    }
+
+    public boolean isBoxedPrimitive() {
+        return equals(BOOLEAN) || equals(BYTE) || equals(CHARACTER) ||
+                equals(DOUBLE) || equals(FLOAT) || equals(INTEGER) ||
+                equals(LONG) || equals(SHORT) || equals(VOID);
+    }
+
+    public PrimitiveTypeRef unbox() {
+        Preconditions.requireState(packageName.equals("java.lang"), "Package name must be 'java.lang'");
+
+        switch (name) {
+            case "Boolean": return PrimitiveTypeRef.BOOLEAN;
+            case "Byte": return PrimitiveTypeRef.BYTE;
+            case "Character": return PrimitiveTypeRef.CHAR;
+            case "Double": return PrimitiveTypeRef.DOUBLE;
+            case "Float": return PrimitiveTypeRef.FLOAT;
+            case "Integer": return PrimitiveTypeRef.INT;
+            case "Long": return PrimitiveTypeRef.LONG;
+            case "Short": return PrimitiveTypeRef.SHORT;
+            case "Void": return PrimitiveTypeRef.VOID;
+            default: throw new IllegalStateException("Unexpected value: '" + name + "'");
+        }
+    }
+
+    public ClassRef peer(String name) {
+        return new ClassRef(packageName, name, enclosing);
+    }
+
+    public ClassRef nested(String name) {
+        return new ClassRef(packageName, name, this);
+    }
+
+    public ClassRef topLevel() {
+        if (enclosing == null) {
+            return this;
+        }
+
+        ClassRef enc = enclosing;
+        ClassRef prev = enclosing;
+
+        while (true) {
+            if (enc == null) {
+                return prev;
+            }
+
+            prev = enc;
+            enc = enc.enclosing;
+        }
+    }
+
+    public String qualifiedName() {
+        if (packageName.isEmpty()) {
+            return name;
+        }
+        if (enclosing != null) {
+            return enclosing.qualifiedName() + '.' + name;
+        }
+        return packageName + '.' + name;
+    }
+
+    @Override
+    public String getTypeName() {
+        return qualifiedName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClassRef classRef = (ClassRef) o;
+        return qualifiedName().equals(classRef.qualifiedName());
+    }
+
+    @Override
+    public int hashCode() {
+        return qualifiedName().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        if (enclosing == null) {
+            return name;
+        }
+        return enclosing.name + '.' + name;
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRenderer.java
@@ -3,6 +3,7 @@ package telegram4j.tl.generator.renderer;
 import telegram4j.tl.generator.Preconditions;
 
 import javax.lang.model.element.Modifier;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
@@ -97,12 +98,12 @@ public class ClassRenderer<P extends BaseClassRenderer<?>> extends BaseClassRend
     }
 
     @Override
-    public ClassRenderer<P> addAnnotations(Type... annotations) {
-        return (ClassRenderer<P>) super.addAnnotations(annotations);
+    public ClassRenderer<P> addAnnotation(Class<? extends Annotation> annotation) {
+        return (ClassRenderer<P>) super.addAnnotation(annotation);
     }
 
     @Override
-    public ClassRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+    public ClassRenderer<P> addAnnotations(Iterable<Class<? extends Annotation>> annotations) {
         return (ClassRenderer<P>) super.addAnnotations(annotations);
     }
 

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRenderer.java
@@ -57,7 +57,7 @@ public class ClassRenderer<P extends BaseClassRenderer<?>> extends BaseClassRend
     @Override
     public InitializerRenderer<ClassRenderer<P>> addStaticInitializer() {
         Preconditions.requireState(kind == Kind.CLASS || kind == Kind.ENUM,
-                "Static initializers is not allowed in " + kind);
+                "Static initializers are not allowed in " + kind);
         if (stage != PROCESSING) {
             requireStage(ANNOTATIONS, PROCESSING);
             completeStage(PROCESSING);
@@ -68,7 +68,7 @@ public class ClassRenderer<P extends BaseClassRenderer<?>> extends BaseClassRend
     @Override
     public InitializerRenderer<ClassRenderer<P>> addInitializer() {
         Preconditions.requireState(kind == Kind.CLASS || kind == Kind.ENUM,
-                "Static initializers is not allowed in " + kind);
+                "Static initializers are not allowed in " + kind);
         if (stage != PROCESSING) {
             requireStage(ANNOTATIONS, PROCESSING);
             completeStage(PROCESSING);
@@ -89,6 +89,11 @@ public class ClassRenderer<P extends BaseClassRenderer<?>> extends BaseClassRend
     @Override
     public ClassRenderer<P> addModifiers(Modifier... modifiers) {
         return (ClassRenderer<P>) super.addModifiers(modifiers);
+    }
+
+    @Override
+    public ClassRenderer<P> addAnnotation(AnnotationRenderer renderer) {
+        return (ClassRenderer<P>) super.addAnnotation(renderer);
     }
 
     @Override

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRenderer.java
@@ -107,11 +107,6 @@ public class ClassRenderer<P extends BaseClassRenderer<?>> extends BaseClassRend
     }
 
     @Override
-    public ClassRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
-        return (ClassRenderer<P>) super.addAnnotations(inline, annotations);
-    }
-
-    @Override
     public ClassRenderer<P> addSuperType(Type type) {
         return (ClassRenderer<P>) super.addSuperType(type);
     }

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ClassRenderer.java
@@ -1,0 +1,218 @@
+package telegram4j.tl.generator.renderer;
+
+import telegram4j.tl.generator.Preconditions;
+
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.ANNOTATIONS;
+import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.PROCESSING;
+
+@SuppressWarnings("unchecked")
+public class ClassRenderer<P extends BaseClassRenderer<?>> extends BaseClassRenderer<P> {
+
+    public static final String DEFAULT_INDENT = "\t";
+    public static final int DEFAULT_LINE_WRAP = 120;
+
+    protected final TopLevelRenderer parent;
+    protected final P enclosing;
+
+    protected ClassRenderer(ClassRef name, Kind kind, TopLevelRenderer parent, P enclosing) {
+        super(name, kind, parent.out);
+        this.parent = parent;
+        this.enclosing = enclosing;
+    }
+
+    public static TopLevelRenderer create(ClassRef name, Kind kind) {
+        return create(name, kind, DEFAULT_INDENT, DEFAULT_LINE_WRAP);
+    }
+
+    public static TopLevelRenderer create(ClassRef name, Kind kind, String indent, int lineWrap) {
+        return new TopLevelRenderer(name, kind, new CharSink(indent, lineWrap));
+    }
+
+    public ClassRenderer<ClassRenderer<P>> addType(String name, Kind kind) {
+        if (stage != PROCESSING) {
+            requireStage(ANNOTATIONS, PROCESSING);
+            completeStage(PROCESSING);
+        }
+        return addPending(new ClassRenderer<>(this.name.nested(name), kind, parent, this));
+    }
+
+    @Override
+    public ClassRenderer<P> addStaticImports(String... staticImports) {
+        parent.addStaticImports(staticImports);
+        return this;
+    }
+
+    @Override
+    public ClassRenderer<P> addStaticImport(String staticImport) {
+        parent.addStaticImport(staticImport);
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<ClassRenderer<P>> addStaticInitializer() {
+        Preconditions.requireState(kind == Kind.CLASS || kind == Kind.ENUM,
+                "Static initializers is not allowed in " + kind);
+        if (stage != PROCESSING) {
+            requireStage(ANNOTATIONS, PROCESSING);
+            completeStage(PROCESSING);
+        }
+        return addPending(new InitializerRenderer<>(this, true));
+    }
+
+    @Override
+    public InitializerRenderer<ClassRenderer<P>> addInitializer() {
+        Preconditions.requireState(kind == Kind.CLASS || kind == Kind.ENUM,
+                "Static initializers is not allowed in " + kind);
+        if (stage != PROCESSING) {
+            requireStage(ANNOTATIONS, PROCESSING);
+            completeStage(PROCESSING);
+        }
+        return addPending(new InitializerRenderer<>(this, false));
+    }
+
+    @Override
+    public ClassRenderer<P> addTypeVariables(TypeVariableRef first, TypeVariableRef... rest) {
+        return (ClassRenderer<P>) super.addTypeVariables(first, rest);
+    }
+
+    @Override
+    public ClassRenderer<P> addTypeVariables(Collection<TypeVariableRef> types) {
+        return (ClassRenderer<P>) super.addTypeVariables(types);
+    }
+
+    @Override
+    public ClassRenderer<P> addModifiers(Modifier... modifiers) {
+        return (ClassRenderer<P>) super.addModifiers(modifiers);
+    }
+
+    @Override
+    public ClassRenderer<P> addAnnotations(Type... annotations) {
+        return (ClassRenderer<P>) super.addAnnotations(annotations);
+    }
+
+    @Override
+    public ClassRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+        return (ClassRenderer<P>) super.addAnnotations(annotations);
+    }
+
+    @Override
+    public ClassRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
+        return (ClassRenderer<P>) super.addAnnotations(inline, annotations);
+    }
+
+    @Override
+    public ClassRenderer<P> addSuperType(Type type) {
+        return (ClassRenderer<P>) super.addSuperType(type);
+    }
+
+    @Override
+    public ClassRenderer<P> addInterface(Type type) {
+        return (ClassRenderer<P>) super.addInterface(type);
+    }
+
+    @Override
+    public ClassRenderer<P> addInterfaces(List<? extends Type> types) {
+        return (ClassRenderer<P>) super.addInterfaces(types);
+    }
+
+    @Override
+    public ClassRenderer<P> addInterfaces(Type first, Type... rest) {
+        return (ClassRenderer<P>) super.addInterfaces(first, rest);
+    }
+
+    @Override
+    public ClassRenderer<P> addAttribute(Type type, String name) {
+        return (ClassRenderer<P>) super.addAttribute(type, name);
+    }
+
+    @Override
+    public ClassRenderer<P> addAttribute(Type type, String name, CharSequence format, Object... args) {
+        return (ClassRenderer<P>) super.addAttribute(type, name, format, args);
+    }
+
+    @Override
+    public FieldRenderer<ClassRenderer<P>> addField(Type type, String name) {
+        return (FieldRenderer<ClassRenderer<P>>) super.addField(type, name);
+    }
+
+    @Override
+    public FieldRenderer<ClassRenderer<P>> addField(Type type, String name, Modifier... modifiers) {
+        return (FieldRenderer<ClassRenderer<P>>) super.addField(type, name, modifiers);
+    }
+
+    @Override
+    public ExecutableRenderer<ClassRenderer<P>> addConstructor() {
+        return (ExecutableRenderer<ClassRenderer<P>>) super.addConstructor();
+    }
+
+    @Override
+    public ExecutableRenderer<ClassRenderer<P>> addConstructor(Modifier... modifiers) {
+        return (ExecutableRenderer<ClassRenderer<P>>) super.addConstructor(modifiers);
+    }
+
+    @Override
+    public MethodRenderer<ClassRenderer<P>> addMethod(Type returnType, String name) {
+        return (MethodRenderer<ClassRenderer<P>>) super.addMethod(returnType, name);
+    }
+
+    @Override
+    public MethodRenderer<ClassRenderer<P>> addMethod(Type returnType, String name, Modifier... modifiers) {
+        return (MethodRenderer<ClassRenderer<P>>) super.addMethod(returnType, name, modifiers);
+    }
+
+    @Override
+    public ClassRenderer<P> addConstant(CharSequence name, CharSequence format, Object... args) {
+        return (ClassRenderer<P>) super.addConstant(name, format, args);
+    }
+
+    @Override
+    public ClassRenderer<P> addConstant(CharSequence name) {
+        return (ClassRenderer<P>) super.addConstant(name);
+    }
+
+    @Override
+    protected void appendType(CharSink out, TypeRef type, boolean vararg) {
+        parent.appendType(out, type, vararg);
+    }
+
+    @Override
+    protected void appendType(CharSink out, TypeRef type) {
+        parent.appendType(out, type);
+    }
+
+    @Override
+    protected void separate0() {
+        out.ln();
+    }
+
+    @Override
+    public P complete() {
+        if (stage != Stage.COMPLETE) {
+            completePending();
+
+            complete0();
+            stage = Stage.COMPLETE;
+        }
+        return enclosing;
+    }
+
+    public enum Kind {
+        CLASS,
+        INTERFACE,
+        ENUM,
+        ANNOTATION;
+
+        protected String asKeyword() {
+            if (this == ANNOTATION) {
+                return "@interface";
+            }
+            return name().toLowerCase(Locale.US);
+        }
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/CodeRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/CodeRenderer.java
@@ -1,0 +1,42 @@
+package telegram4j.tl.generator.renderer;
+
+public interface CodeRenderer<P> extends CompletableRenderer<P> {
+
+    CodeRenderer<P> addStatementFormatted(CharSequence code);
+
+    CodeRenderer<P> addStatement(CharSequence code);
+
+    CodeRenderer<P> addStatement(CharSequence format, Object... args);
+
+    CodeRenderer<P> addCode(char c);
+
+    CodeRenderer<P> addCode(CharSequence code);
+
+    CodeRenderer<P> addCode(CharSequence format, Object... args);
+
+    CodeRenderer<P> beginControlFlow(CharSequence code);
+
+    CodeRenderer<P> beginControlFlow(CharSequence format, Object... args);
+
+    CodeRenderer<P> nextControlFlow(CharSequence code);
+
+    CodeRenderer<P> nextControlFlow(CharSequence format, Object... args);
+
+    CodeRenderer<P> endControlFlow();
+
+    CodeRenderer<P> endControlFlow(CharSequence code);
+
+    CodeRenderer<P> endControlFlow(CharSequence format, Object... args);
+
+    CodeRenderer<P> incIndent();
+
+    CodeRenderer<P> incIndent(int count);
+
+    CodeRenderer<P> decIndent();
+
+    CodeRenderer<P> decIndent(int count);
+
+    CodeRenderer<P> ln();
+
+    CodeRenderer<P> ln(int count);
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/CodeRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/CodeRenderer.java
@@ -12,6 +12,8 @@ public interface CodeRenderer<P> extends CompletableRenderer<P> {
 
     CodeRenderer<P> addCode(CharSequence code);
 
+    CodeRenderer<P> addCodeFormatted(CharSequence code);
+
     CodeRenderer<P> addCode(CharSequence format, Object... args);
 
     CodeRenderer<P> beginControlFlow(CharSequence code);

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/CodeRendererImpl.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/CodeRendererImpl.java
@@ -1,0 +1,185 @@
+package telegram4j.tl.generator.renderer;
+
+class CodeRendererImpl implements CodeRenderer<CharSequence> {
+    private final BaseClassRenderer<?> parent;
+    private final CharSink out;
+
+    private Stage stage = Stage.PROCESSING;
+
+    CodeRendererImpl(BaseClassRenderer<?> parent, CharSink out) {
+        this.parent = parent;
+        this.out = out;
+    }
+
+    @Override
+    public Stage stage() {
+        return stage;
+    }
+
+    @Override
+    public CharSequence complete() {
+        if (stage != Stage.COMPLETE) {
+            stage = Stage.COMPLETE;
+        }
+        return out.asStringBuilder();
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> addStatementFormatted(CharSequence code) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        parent.formatCode(out, code);
+        out.append(';').ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> addStatement(CharSequence code) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.append(code).append(';').ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> addStatement(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        parent.formatCode(out, format, args);
+        out.append(';').ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> addCode(char c) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.append(c);
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> addCode(CharSequence code) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.append(code);
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> addCode(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        parent.formatCode(out, format, args);
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> beginControlFlow(CharSequence code) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.append(code).incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> beginControlFlow(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        parent.formatCode(out, format, args);
+        out.incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> nextControlFlow(CharSequence code) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.decIndent().append(code).incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> nextControlFlow(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.decIndent();
+        parent.formatCode(out, format, args);
+        out.incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> endControlFlow() {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.append('}').decIndent().ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> endControlFlow(CharSequence code) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.decIndent().append(code).ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> endControlFlow(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.decIndent();
+        parent.formatCode(out, format, args);
+        out.ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> incIndent() {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.incIndent();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> incIndent(int count) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.incIndent(count);
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> decIndent() {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.decIndent();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> decIndent(int count) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.decIndent(count);
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> ln() {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.ln();
+        return this;
+    }
+
+    @Override
+    public CodeRenderer<CharSequence> ln(int count) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        out.ln(count);
+        return this;
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/CodeRendererImpl.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/CodeRendererImpl.java
@@ -67,6 +67,14 @@ class CodeRendererImpl implements CodeRenderer<CharSequence> {
     }
 
     @Override
+    public CodeRenderer<CharSequence> addCodeFormatted(CharSequence code) {
+        RenderUtils.requireStage(stage, Stage.PROCESSING);
+
+        parent.formatCode(out, code);
+        return this;
+    }
+
+    @Override
     public CodeRenderer<CharSequence> addCode(CharSequence format, Object... args) {
         RenderUtils.requireStage(stage, Stage.PROCESSING);
 

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/CompletableRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/CompletableRenderer.java
@@ -1,0 +1,34 @@
+package telegram4j.tl.generator.renderer;
+
+public interface CompletableRenderer<P> {
+
+    Stage stage();
+
+    P complete();
+
+    class Stage implements Comparable<Stage> {
+        public static final Stage ANNOTATIONS = new Stage(-1, "ANNOTATIONS");
+        public static final Stage MODIFIERS = new Stage(0, "MODIFIERS");
+        public static final Stage TYPE_VARIABLES = new Stage(1, "TYPE_VARIABLES");
+        public static final Stage PROCESSING = new Stage(Integer.MAX_VALUE - 1, "PROCESSING");
+        public static final Stage COMPLETE = new Stage(Integer.MAX_VALUE, "COMPLETE");
+
+        public final int index;
+        public final String name;
+
+        public Stage(int index, String name) {
+            this.index = index;
+            this.name = name;
+        }
+
+        @Override
+        public int compareTo(Stage o) {
+            return Integer.compare(index, o.index);
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
@@ -22,6 +22,12 @@ public class ExecutableRenderer<P extends BaseClassRenderer<?>>
         this.name = name;
     }
 
+    public ExecutableRenderer<P> addAnnotation(AnnotationRenderer renderer) {
+        RenderUtils.requireStage(stage, ANNOTATIONS);
+        out.append(renderer.complete());
+        return this;
+    }
+
     public ExecutableRenderer<P> addAnnotations(Type... annotations) {
         return addAnnotations(false, Arrays.asList(annotations));
     }

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
@@ -1,0 +1,343 @@
+package telegram4j.tl.generator.renderer;
+
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.*;
+
+public class ExecutableRenderer<P extends BaseClassRenderer<?>>
+        extends BaseCompletableRenderer<P>
+        implements CodeRenderer<P> {
+
+    protected static final Stage PARAMETERS = new Stage(2, "PARAMETERS"),
+            EXCEPTIONS = new Stage(3, "EXCEPTIONS"),
+            BODY = new Stage(4, "BODY");
+
+    protected final String name;
+
+    protected ExecutableRenderer(P parent, String name) {
+        super(parent, ANNOTATIONS);
+        this.name = name;
+    }
+
+    public ExecutableRenderer<P> addAnnotations(Type... annotations) {
+        return addAnnotations(false, Arrays.asList(annotations));
+    }
+
+    public ExecutableRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+        return addAnnotations(false, annotations);
+    }
+
+    public ExecutableRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
+        RenderUtils.requireStage(stage, ANNOTATIONS);
+        parent.appendAnnotations(out, inline, annotations);
+        return this;
+    }
+
+    public ExecutableRenderer<P> addModifiers(Collection<Modifier> modifiers) {
+        RenderUtils.requireStage(stage, ANNOTATIONS, MODIFIERS);
+        parent.appendModifiers(out, modifiers);
+        return this;
+    }
+
+    public ExecutableRenderer<P> addModifiers(Modifier... modifiers) {
+        RenderUtils.requireStage(stage, ANNOTATIONS, MODIFIERS);
+        parent.appendModifiers(out, modifiers);
+        return this;
+    }
+
+    public ExecutableRenderer<P> addParameter(Type type, String name) {
+        return addParameter(type, name, false);
+    }
+
+    public ExecutableRenderer<P> addParameter(Type type, String name, boolean vararg) {
+        if (stage != PARAMETERS) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, PARAMETERS);
+            completeStage(PARAMETERS);
+        } else {
+            out.append(", ").lw();
+        }
+
+        parent.appendType(out, TypeRef.of(type), vararg);
+        out.append(' ');
+        out.append(name);
+        return this;
+    }
+
+    public ExecutableRenderer<P> addExceptions(Type first, Type... rest) {
+        if (stage != EXCEPTIONS) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, PARAMETERS);
+            completeStage(EXCEPTIONS);
+
+            out.append(" throws ");
+        }
+
+        parent.appendType(out, TypeRef.of(first));
+        for (Type t : rest) {
+            out.append(", ").lw();
+            parent.appendType(out, TypeRef.of(t));
+        }
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> addStatementFormatted(CharSequence code) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        parent.formatCode(out, code);
+        out.append(';').ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> addStatement(CharSequence code) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.append(code).append(';').ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> addStatement(CharSequence format, Object... args) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        parent.formatCode(out, format, args);
+        out.append(';').ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> addCode(char c) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.append(c);
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> addCode(CharSequence code) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.append(code);
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> addCode(CharSequence format, Object... args) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        parent.formatCode(out, format, args);
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> beginControlFlow(CharSequence code) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.append(code).incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> beginControlFlow(CharSequence format, Object... args) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        parent.formatCode(out, format, args);
+        out.incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> nextControlFlow(CharSequence code) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.decIndent().append(code).incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> nextControlFlow(CharSequence format, Object... args) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.decIndent();
+        parent.formatCode(out, format, args);
+        out.incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> endControlFlow() {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.decIndent().append('}').ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> endControlFlow(CharSequence code) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.decIndent().append(code).ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> endControlFlow(CharSequence format, Object... args) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.decIndent();
+        parent.formatCode(out, format, args);
+        out.ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> incIndent() {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.incIndent();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> incIndent(int count) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.incIndent(count);
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> decIndent() {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.decIndent();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> decIndent(int count) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.decIndent(count);
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> ln() {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.ln();
+        return this;
+    }
+
+    @Override
+    public ExecutableRenderer<P> ln(int count) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        out.ln(count);
+        return this;
+    }
+
+    protected void completeStage(Stage required) {
+        do {
+            // [ annotations ]
+            // [ modifiers ] [return type & name]([parameters]) throws [exceptions] { [body] }
+            if (stage == ANNOTATIONS) {
+                stage = MODIFIERS;
+            } else if (stage == MODIFIERS) {
+                stage = PARAMETERS;
+                out.append(name);
+                out.append('(');
+            } else if (stage == PARAMETERS) {
+                stage = EXCEPTIONS;
+                out.append(')');
+            } else if (stage == EXCEPTIONS) {
+                stage = BODY;
+                out.incIndent();
+                out.append(" {").ln();
+            }
+        } while (stage != required);
+    }
+
+    @Override
+    protected void complete0() {
+        if (stage == ANNOTATIONS || stage == MODIFIERS) {
+            stage = PARAMETERS;
+            out.append(name);
+            out.append('(');
+        }
+
+        if (stage == PARAMETERS) {
+            stage = EXCEPTIONS;
+            out.append(')');
+        }
+
+        if (stage == EXCEPTIONS) {
+            out.append(" {}").ln();
+        }
+
+        if (stage == BODY) {
+            out.decIndent().lno().append('}').ln();
+        }
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
@@ -140,6 +140,17 @@ public class ExecutableRenderer<P extends BaseClassRenderer<?>>
     }
 
     @Override
+    public ExecutableRenderer<P> addCodeFormatted(CharSequence code) {
+        if (stage != BODY) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);
+            completeStage(BODY);
+        }
+
+        parent.formatCode(out, code);
+        return this;
+    }
+
+    @Override
     public ExecutableRenderer<P> addCode(CharSequence format, Object... args) {
         if (stage != BODY) {
             RenderUtils.requireStage(stage, ANNOTATIONS, EXCEPTIONS);

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
@@ -9,7 +9,7 @@ import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.*;
 
 public class ExecutableRenderer<P extends BaseClassRenderer<?>>
         extends BaseCompletableRenderer<P>
-        implements CodeRenderer<P> {
+        implements CodeRenderer<P>, AnnotatedRenderer<P> {
 
     protected static final Stage PARAMETERS = new Stage(2, "PARAMETERS"),
             EXCEPTIONS = new Stage(3, "EXCEPTIONS"),
@@ -22,23 +22,22 @@ public class ExecutableRenderer<P extends BaseClassRenderer<?>>
         this.name = name;
     }
 
+    @Override
     public ExecutableRenderer<P> addAnnotation(AnnotationRenderer renderer) {
         RenderUtils.requireStage(stage, ANNOTATIONS);
         out.append(renderer.complete());
         return this;
     }
 
+    @Override
     public ExecutableRenderer<P> addAnnotations(Type... annotations) {
-        return addAnnotations(false, Arrays.asList(annotations));
+        return addAnnotations(Arrays.asList(annotations));
     }
 
+    @Override
     public ExecutableRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
-        return addAnnotations(false, annotations);
-    }
-
-    public ExecutableRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
         RenderUtils.requireStage(stage, ANNOTATIONS);
-        parent.appendAnnotations(out, inline, annotations);
+        parent.appendAnnotations(out, annotations);
         return this;
     }
 

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ExecutableRenderer.java
@@ -1,9 +1,11 @@
 package telegram4j.tl.generator.renderer;
 
 import javax.lang.model.element.Modifier;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.*;
 
@@ -30,12 +32,12 @@ public class ExecutableRenderer<P extends BaseClassRenderer<?>>
     }
 
     @Override
-    public ExecutableRenderer<P> addAnnotations(Type... annotations) {
-        return addAnnotations(Arrays.asList(annotations));
+    public ExecutableRenderer<P> addAnnotation(Class<? extends Annotation> annotation) {
+        return addAnnotations(List.of(annotation));
     }
 
     @Override
-    public ExecutableRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+    public ExecutableRenderer<P> addAnnotations(Iterable<Class<? extends Annotation>> annotations) {
         RenderUtils.requireStage(stage, ANNOTATIONS);
         parent.appendAnnotations(out, annotations);
         return this;

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/FieldRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/FieldRenderer.java
@@ -1,6 +1,7 @@
 package telegram4j.tl.generator.renderer;
 
 import javax.lang.model.element.Modifier;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.*;
 
@@ -43,12 +44,12 @@ public class FieldRenderer<P extends BaseClassRenderer<?>>
     }
 
     @Override
-    public FieldRenderer<P> addAnnotations(Type... annotations) {
-        return addAnnotations(Arrays.asList(annotations));
+    public FieldRenderer<P> addAnnotation(Class<? extends Annotation> annotation) {
+        return addAnnotations(List.of(annotation));
     }
 
     @Override
-    public FieldRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+    public FieldRenderer<P> addAnnotations(Iterable<Class<? extends Annotation>> annotations) {
         RenderUtils.requireStage(stage, ANNOTATIONS);
         parent.appendAnnotations(out, annotations);
         return this;

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/FieldRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/FieldRenderer.java
@@ -1,0 +1,97 @@
+package telegram4j.tl.generator.renderer;
+
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Type;
+import java.util.*;
+
+import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.ANNOTATIONS;
+import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.MODIFIERS;
+
+public class FieldRenderer<P extends BaseClassRenderer<?>>
+        extends BaseCompletableRenderer<P>
+        implements SeparableRenderer<P> {
+
+    private static final Stage INITIALIZER = new Stage(1, "INITIALIZER");
+
+    protected final TypeRef type;
+    protected final String name;
+
+    // cached for comparing in #separate
+    private final EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+
+    protected FieldRenderer(P parent, TypeRef type, String name) {
+        super(parent, ANNOTATIONS);
+        this.type = Objects.requireNonNull(type);
+        this.name = Objects.requireNonNull(name);
+    }
+
+    private void completeStage() {
+        if (stage == ANNOTATIONS || stage == MODIFIERS) {
+            stage = INITIALIZER;
+
+            parent.appendType(out, type);
+            out.append(' ');
+            out.append(name);
+        }
+    }
+
+    public FieldRenderer<P> addAnnotations(Type... annotations) {
+        return addAnnotations(false, Arrays.asList(annotations));
+    }
+
+    public FieldRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+        return addAnnotations(false, annotations);
+    }
+
+    public FieldRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
+        RenderUtils.requireStage(stage, ANNOTATIONS);
+        parent.appendAnnotations(out, inline, annotations);
+        return this;
+    }
+
+    public FieldRenderer<P> addModifiers(Modifier... modifiers) {
+        RenderUtils.requireStage(stage, ANNOTATIONS, MODIFIERS);
+        parent.appendModifiers(out, modifiers);
+        Collections.addAll(this.modifiers, modifiers);
+        return this;
+    }
+
+    public FieldRenderer<P> initializer(CharSequence format, Object... args) {
+        completeStage();
+        RenderUtils.requireStage(stage, INITIALIZER);
+
+        out.append(" = ");
+        parent.formatCode(out, format, args);
+        out.append(';').ln();
+        return this;
+    }
+
+    public FieldRenderer<P> initializer(CharSequence value) {
+        completeStage();
+        RenderUtils.requireStage(stage, INITIALIZER);
+
+        out.append(" = ");
+        out.append(value);
+        out.append(';').ln();
+        return this;
+    }
+
+    @Override
+    public <T extends CompletableRenderer<?>> boolean separate(T child) {
+        if (!(child instanceof FieldRenderer)) {
+            return true;
+        }
+        FieldRenderer<?> f = (FieldRenderer<?>) child;
+        return !modifiers.equals(f.modifiers);
+    }
+
+    @Override
+    protected void complete0() {
+        if (stage == ANNOTATIONS || stage == MODIFIERS) {
+            parent.appendType(out, type);
+            out.append(' ');
+            out.append(name);
+            out.append(';').ln();
+        }
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/FieldRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/FieldRenderer.java
@@ -16,7 +16,7 @@ public class FieldRenderer<P extends BaseClassRenderer<?>>
     protected final TypeRef type;
     protected final String name;
 
-    // cached for comparing in #separate
+    // cached for comparing in separate(T)
     private final EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
 
     protected FieldRenderer(P parent, TypeRef type, String name) {

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/FieldRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/FieldRenderer.java
@@ -9,7 +9,7 @@ import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.MODIFIE
 
 public class FieldRenderer<P extends BaseClassRenderer<?>>
         extends BaseCompletableRenderer<P>
-        implements SeparableRenderer<P> {
+        implements SeparableRenderer<P>, AnnotatedRenderer<P> {
 
     private static final Stage INITIALIZER = new Stage(1, "INITIALIZER");
 
@@ -35,17 +35,22 @@ public class FieldRenderer<P extends BaseClassRenderer<?>>
         }
     }
 
-    public FieldRenderer<P> addAnnotations(Type... annotations) {
-        return addAnnotations(false, Arrays.asList(annotations));
-    }
-
-    public FieldRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
-        return addAnnotations(false, annotations);
-    }
-
-    public FieldRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
+    @Override
+    public AnnotatedRenderer<P> addAnnotation(AnnotationRenderer renderer) {
         RenderUtils.requireStage(stage, ANNOTATIONS);
-        parent.appendAnnotations(out, inline, annotations);
+        out.append(renderer.complete());
+        return this;
+    }
+
+    @Override
+    public FieldRenderer<P> addAnnotations(Type... annotations) {
+        return addAnnotations(Arrays.asList(annotations));
+    }
+
+    @Override
+    public FieldRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+        RenderUtils.requireStage(stage, ANNOTATIONS);
+        parent.appendAnnotations(out, annotations);
         return this;
     }
 

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/InitializerRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/InitializerRenderer.java
@@ -1,0 +1,166 @@
+package telegram4j.tl.generator.renderer;
+
+import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.PROCESSING;
+
+public class InitializerRenderer<P extends BaseClassRenderer<?>>
+        extends BaseCompletableRenderer<P>
+        implements CodeRenderer<P> {
+
+    protected InitializerRenderer(P parent, boolean isStatic) {
+        super(parent, PROCESSING);
+
+        if (isStatic) {
+            out.append("static {");
+        } else {
+            out.append('{');
+        }
+
+        out.incIndent().ln();
+    }
+
+    @Override
+    protected void complete0() {
+        out.decIndent();
+        out.lno().append('}');
+    }
+
+    @Override
+    public InitializerRenderer<P> addStatementFormatted(CharSequence code) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        parent.formatCode(out, code);
+        out.append(';').ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> addStatement(CharSequence code) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.append(code).append(';').ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> addStatement(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        parent.formatCode(out, format, args);
+        out.append(';').ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> addCode(char c) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.append(c);
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> addCode(CharSequence code) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.append(code);
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> addCode(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        parent.formatCode(out, format, args);
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> beginControlFlow(CharSequence code) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.append(code).incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> beginControlFlow(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        parent.formatCode(out, format, args);
+        out.incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> nextControlFlow(CharSequence code) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.decIndent().append(code).incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> nextControlFlow(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.decIndent();
+        parent.formatCode(out, format, args);
+        out.incIndent().ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> endControlFlow() {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.append('}').decIndent().ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> endControlFlow(CharSequence code) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.decIndent().append(code).ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> endControlFlow(CharSequence format, Object... args) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.decIndent();
+        parent.formatCode(out, format, args);
+        out.ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> incIndent() {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.incIndent();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> incIndent(int count) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.incIndent(count);
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> decIndent() {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.decIndent();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> decIndent(int count) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.decIndent(count);
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> ln() {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.ln();
+        return this;
+    }
+
+    @Override
+    public InitializerRenderer<P> ln(int count) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        out.ln(count);
+        return this;
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/InitializerRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/InitializerRenderer.java
@@ -62,6 +62,13 @@ public class InitializerRenderer<P extends BaseClassRenderer<?>>
     }
 
     @Override
+    public InitializerRenderer<P> addCodeFormatted(CharSequence code) {
+        RenderUtils.requireStage(stage, PROCESSING);
+        parent.formatCode(out, code);
+        return this;
+    }
+
+    @Override
     public InitializerRenderer<P> addCode(CharSequence format, Object... args) {
         RenderUtils.requireStage(stage, PROCESSING);
         parent.formatCode(out, format, args);

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
@@ -1,0 +1,302 @@
+package telegram4j.tl.generator.renderer;
+
+import telegram4j.tl.generator.Preconditions;
+
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+
+import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.*;
+
+public class MethodRenderer<P extends BaseClassRenderer<?>> extends ExecutableRenderer<P> {
+
+    private final TypeRef returnType;
+    private final EnumSet<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
+
+    protected MethodRenderer(P parent, String name, TypeRef returnType) {
+        super(parent, name);
+        this.returnType = returnType;
+    }
+
+    public MethodRenderer<P> addTypeVariables(Collection<TypeVariableRef> types) {
+        if (types.isEmpty()) {
+            return this;
+        }
+
+        if (stage != TYPE_VARIABLES) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, TYPE_VARIABLES);
+            stage = TYPE_VARIABLES;
+
+            out.append('<');
+        } else {
+            out.append(", ").lw();
+        }
+
+        boolean first = true;
+        for (TypeVariableRef type : types) {
+            if (first) {
+                first = false;
+            } else {
+                out.append(", ").lw();
+            }
+
+            parent.appendTypeVariable(out, type);
+        }
+        return this;
+    }
+
+    public MethodRenderer<P> addTypeVariables(TypeVariableRef first, TypeVariableRef... rest) {
+        if (stage != TYPE_VARIABLES) {
+            RenderUtils.requireStage(stage, ANNOTATIONS, TYPE_VARIABLES);
+            stage = TYPE_VARIABLES;
+
+            out.append('<');
+        } else {
+            out.append(", ").lw();
+        }
+
+        parent.appendTypeVariable(out, first);
+        for (TypeVariableRef t : rest) {
+            out.append(", ").lw();
+            parent.appendTypeVariable(out, t);
+        }
+        return this;
+    }
+
+    @Override
+    public MethodRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
+        return (MethodRenderer<P>) super.addAnnotations(annotations);
+    }
+
+    @Override
+    public MethodRenderer<P> addAnnotations(Type... annotations) {
+        return (MethodRenderer<P>) super.addAnnotations(annotations);
+    }
+
+    @Override
+    public MethodRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
+        return (MethodRenderer<P>) super.addAnnotations(inline, annotations);
+    }
+
+    @Override
+    public MethodRenderer<P> addModifiers(Collection<Modifier> modifiers) {
+        this.modifiers.addAll(modifiers);
+        return (MethodRenderer<P>) super.addModifiers(modifiers);
+    }
+
+    @Override
+    public MethodRenderer<P> addModifiers(Modifier... modifiers) {
+        this.modifiers.addAll(Arrays.asList(modifiers));
+        return (MethodRenderer<P>) super.addModifiers(modifiers);
+    }
+
+    @Override
+    public MethodRenderer<P> addParameter(Type type, String name) {
+        return (MethodRenderer<P>) super.addParameter(type, name);
+    }
+
+    @Override
+    public MethodRenderer<P> addParameter(Type type, String name, boolean vararg) {
+        return (MethodRenderer<P>) super.addParameter(type, name, vararg);
+    }
+
+    @Override
+    public MethodRenderer<P> addExceptions(Type first, Type... rest) {
+        return (MethodRenderer<P>) super.addExceptions(first, rest);
+    }
+
+    @Override
+    public MethodRenderer<P> addStatement(CharSequence code) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.addStatement(code);
+    }
+
+    @Override
+    public MethodRenderer<P> addStatementFormatted(CharSequence code) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.addStatementFormatted(code);
+    }
+
+    @Override
+    public MethodRenderer<P> addStatement(CharSequence format, Object... args) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.addStatement(format, args);
+    }
+
+    @Override
+    public MethodRenderer<P> addCode(char c) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.addCode(c);
+    }
+
+    @Override
+    public MethodRenderer<P> addCode(CharSequence code) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.addCode(code);
+    }
+
+    @Override
+    public MethodRenderer<P> addCode(CharSequence format, Object... args) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.addCode(format, args);
+    }
+
+    @Override
+    public MethodRenderer<P> beginControlFlow(CharSequence code) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.beginControlFlow(code);
+    }
+
+    @Override
+    public MethodRenderer<P> beginControlFlow(CharSequence format, Object... args) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.beginControlFlow(format, args);
+    }
+
+    @Override
+    public MethodRenderer<P> nextControlFlow(CharSequence code) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.nextControlFlow(code);
+    }
+
+    @Override
+    public MethodRenderer<P> nextControlFlow(CharSequence format, Object... args) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.nextControlFlow(format, args);
+    }
+
+    @Override
+    public MethodRenderer<P> endControlFlow() {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.endControlFlow();
+    }
+
+    @Override
+    public MethodRenderer<P> endControlFlow(CharSequence code) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.endControlFlow(code);
+    }
+
+    @Override
+    public MethodRenderer<P> endControlFlow(CharSequence format, Object... args) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.endControlFlow(format, args);
+    }
+
+    @Override
+    public MethodRenderer<P> incIndent() {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.incIndent();
+    }
+
+    @Override
+    public MethodRenderer<P> incIndent(int count) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.incIndent(count);
+    }
+
+    @Override
+    public MethodRenderer<P> decIndent() {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.decIndent();
+    }
+
+    @Override
+    public MethodRenderer<P> decIndent(int count) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.decIndent(count);
+    }
+
+    @Override
+    public MethodRenderer<P> ln() {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.ln();
+    }
+
+    @Override
+    public MethodRenderer<P> ln(int count) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.ln(count);
+    }
+
+    private void requireNotAbstract() {
+        if (parent.kind == ClassRenderer.Kind.INTERFACE) {
+            Preconditions.requireState(modifiers.contains(Modifier.DEFAULT) || modifiers.contains(Modifier.STATIC),
+                    "Interface methods can not have a body");
+        } else if (parent.kind == ClassRenderer.Kind.CLASS) {
+            Preconditions.requireState(!modifiers.contains(Modifier.ABSTRACT), "Abstract methods can not have a body");
+        }
+    }
+
+    @Override
+    protected void completeStage(Stage required) {
+        do {
+            // [ annotations ]
+            // [ modifiers ] <[type variables]> [return type & name]([parameters]) throws [exceptions] { [body] }
+            if (stage == ANNOTATIONS) {
+                stage = MODIFIERS;
+            } else if (stage == MODIFIERS) {
+                stage = PARAMETERS;
+
+                parent.appendType(out, returnType);
+                out.append(' ');
+                out.append(name);
+                out.append('(');
+            } else if (stage == TYPE_VARIABLES) { // optional
+                stage = PARAMETERS;
+                out.append("> ");
+
+                parent.appendType(out, returnType);
+                out.append(' ');
+                out.append(name);
+                out.append('(');
+            } else if (stage == PARAMETERS) {
+                stage = EXCEPTIONS;
+                out.append(')');
+            } else if (stage == EXCEPTIONS) {
+                stage = BODY;
+                out.incIndent();
+                out.append(" {").ln();
+            }
+        } while (stage != required);
+    }
+
+    @Override
+    protected void complete0() {
+        if (stage == MODIFIERS || stage == ANNOTATIONS) {
+            stage = PARAMETERS;
+            parent.appendType(out, returnType);
+            out.append(' ');
+            out.append(name);
+            out.append('(');
+        }
+
+        if (stage == TYPE_VARIABLES) { // optional stage
+            stage = PARAMETERS;
+            out.append("> ");
+        }
+
+        if (stage == PARAMETERS) {
+            stage = EXCEPTIONS;
+            out.append(')');
+        }
+
+        boolean cantHaveBody = parent.kind == ClassRenderer.Kind.INTERFACE &&
+                !modifiers.contains(Modifier.STATIC) && !modifiers.contains(Modifier.DEFAULT) ||
+                parent.kind == ClassRenderer.Kind.CLASS && modifiers.contains(Modifier.ABSTRACT);
+
+        if (stage == EXCEPTIONS) {
+            if (cantHaveBody) {
+                out.append(';').ln();
+            } else {
+                out.append(" {}").ln();
+            }
+        }
+
+        if (stage == BODY) {
+            out.decIndent().lno().append('}').ln();
+        }
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
@@ -3,6 +3,7 @@ package telegram4j.tl.generator.renderer;
 import telegram4j.tl.generator.Preconditions;
 
 import javax.lang.model.element.Modifier;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,12 +72,12 @@ public class MethodRenderer<P extends BaseClassRenderer<?>> extends ExecutableRe
     }
 
     @Override
-    public MethodRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
-        return (MethodRenderer<P>) super.addAnnotations(annotations);
+    public MethodRenderer<P> addAnnotation(Class<? extends Annotation> annotation) {
+        return (MethodRenderer<P>) super.addAnnotation(annotation);
     }
 
     @Override
-    public MethodRenderer<P> addAnnotations(Type... annotations) {
+    public MethodRenderer<P> addAnnotations(Iterable<Class<? extends Annotation>> annotations) {
         return (MethodRenderer<P>) super.addAnnotations(annotations);
     }
 

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
@@ -66,6 +66,11 @@ public class MethodRenderer<P extends BaseClassRenderer<?>> extends ExecutableRe
     }
 
     @Override
+    public MethodRenderer<P> addAnnotation(AnnotationRenderer renderer) {
+        return (MethodRenderer<P>) super.addAnnotation(renderer);
+    }
+
+    @Override
     public MethodRenderer<P> addAnnotations(Collection<? extends Type> annotations) {
         return (MethodRenderer<P>) super.addAnnotations(annotations);
     }

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
@@ -81,11 +81,6 @@ public class MethodRenderer<P extends BaseClassRenderer<?>> extends ExecutableRe
     }
 
     @Override
-    public MethodRenderer<P> addAnnotations(boolean inline, Collection<? extends Type> annotations) {
-        return (MethodRenderer<P>) super.addAnnotations(inline, annotations);
-    }
-
-    @Override
     public MethodRenderer<P> addModifiers(Collection<Modifier> modifiers) {
         this.modifiers.addAll(modifiers);
         return (MethodRenderer<P>) super.addModifiers(modifiers);

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/MethodRenderer.java
@@ -138,6 +138,12 @@ public class MethodRenderer<P extends BaseClassRenderer<?>> extends ExecutableRe
     }
 
     @Override
+    public MethodRenderer<P> addCodeFormatted(CharSequence code) {
+        requireNotAbstract();
+        return (MethodRenderer<P>) super.addCodeFormatted(code);
+    }
+
+    @Override
     public MethodRenderer<P> addCode(CharSequence format, Object... args) {
         requireNotAbstract();
         return (MethodRenderer<P>) super.addCode(format, args);

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/ParameterizedTypeRef.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/ParameterizedTypeRef.java
@@ -1,0 +1,82 @@
+package telegram4j.tl.generator.renderer;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ParameterizedTypeRef implements TypeRef {
+    public final ClassRef rawType;
+    public final List<TypeRef> typeArguments;
+
+    private ParameterizedTypeRef(ClassRef rawType, List<TypeRef> typeArguments) {
+        this.rawType = Objects.requireNonNull(rawType);
+        this.typeArguments = Objects.requireNonNull(typeArguments);
+    }
+
+    public static ParameterizedTypeRef of(ClassRef rawType, Collection<? extends TypeRef> typeArguments) {
+        return new ParameterizedTypeRef(rawType, List.copyOf(typeArguments));
+    }
+
+    public static ParameterizedTypeRef of(ClassRef rawType, TypeRef... typeArguments) {
+        return new ParameterizedTypeRef(rawType, List.of(typeArguments));
+    }
+
+    public static ParameterizedTypeRef of(Class<?> rawType, Type... typeArguments) {
+        return new ParameterizedTypeRef(ClassRef.of(rawType), Arrays.stream(typeArguments)
+                .map(TypeRef::of)
+                .collect(Collectors.toUnmodifiableList()));
+    }
+
+    public ParameterizedTypeRef withTypeArguments(Collection<? extends TypeRef> typeArguments) {
+        if (this.typeArguments == typeArguments) return this;
+        return new ParameterizedTypeRef(rawType, List.copyOf(typeArguments));
+    }
+
+    @Override
+    public String getTypeName() {
+        StringBuilder out = new StringBuilder(rawType.getTypeName());
+        if (!typeArguments.isEmpty()) {
+            out.append('<');
+            for (int i = 0, n = typeArguments.size(); i < n; i++) {
+                out.append(typeArguments.get(i).getTypeName());
+                if (i != n - 1) {
+                    out.append(", ");
+                }
+            }
+            out.append('>');
+        }
+        return out.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ParameterizedTypeRef that = (ParameterizedTypeRef) o;
+        return rawType.equals(that.rawType) && typeArguments.equals(that.typeArguments);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rawType, typeArguments);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder out = new StringBuilder(rawType.toString());
+        if (!typeArguments.isEmpty()) {
+            out.append('<');
+            for (int i = 0, n = typeArguments.size(); i < n; i++) {
+                out.append(typeArguments.get(i));
+                if (i != n - 1) {
+                    out.append(", ");
+                }
+            }
+            out.append('>');
+        }
+        return out.toString();
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/PrimitiveTypeRef.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/PrimitiveTypeRef.java
@@ -1,0 +1,31 @@
+package telegram4j.tl.generator.renderer;
+
+import java.util.Locale;
+
+public enum PrimitiveTypeRef implements TypeRef {
+    BOOLEAN(ClassRef.BOOLEAN),
+    BYTE(ClassRef.BYTE),
+    CHAR(ClassRef.CHARACTER),
+    DOUBLE(ClassRef.DOUBLE),
+    FLOAT(ClassRef.FLOAT),
+    INT(ClassRef.INTEGER),
+    LONG(ClassRef.LONG),
+    SHORT(ClassRef.SHORT),
+    VOID(ClassRef.VOID);
+
+    public final ClassRef boxed;
+
+    PrimitiveTypeRef(ClassRef boxed) {
+        this.boxed = boxed;
+    }
+
+    @Override
+    public TypeRef safeBox() {
+        return boxed;
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.US);
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/RenderUtils.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/RenderUtils.java
@@ -1,0 +1,86 @@
+package telegram4j.tl.generator.renderer;
+
+import telegram4j.tl.generator.Preconditions;
+import telegram4j.tl.generator.renderer.CompletableRenderer.Stage;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.*;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.SimpleTypeVisitor9;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+class RenderUtils {
+
+    private RenderUtils() {}
+
+    protected static String operator(int cmp) {
+        if (cmp == 0) {
+            return "==";
+        } else if (cmp > 0) {
+            return ">";
+        } else {
+            return "<";
+        }
+    }
+
+    protected static void requireStage(Stage curr, Stage req) {
+        int cmp = curr.compareTo(req);
+        Preconditions.requireState(cmp == 0, () -> "Unexpected stage, current " +
+                curr + " " + operator(cmp) + " required " + req);
+    }
+
+    protected static void requireStage(Stage curr, Stage min, Stage max) {
+        Preconditions.requireState(curr.compareTo(min) >= 0 && curr.compareTo(max) < 0, () ->
+                "Unexpected stage, current " + curr + " not in range [" + min + ", " + max + ")");
+    }
+
+    protected static TypeRef from(TypeMirror typeMirror) {
+        var visitor = new SimpleTypeVisitor9<TypeRef, Void>() {
+            @Override
+            public TypeRef visitPrimitive(PrimitiveType t, Void p) {
+                switch (t.getKind()) {
+                    case BOOLEAN: return PrimitiveTypeRef.BOOLEAN;
+                    case BYTE: return PrimitiveTypeRef.BYTE;
+                    case SHORT: return PrimitiveTypeRef.SHORT;
+                    case INT: return PrimitiveTypeRef.INT;
+                    case LONG: return PrimitiveTypeRef.LONG;
+                    case CHAR: return PrimitiveTypeRef.CHAR;
+                    case FLOAT: return PrimitiveTypeRef.FLOAT;
+                    case DOUBLE: return PrimitiveTypeRef.DOUBLE;
+                    default: throw new IllegalStateException();
+                }
+            }
+
+            @Override
+            public TypeRef visitDeclared(DeclaredType t, Void p) {
+                if (t.getTypeArguments().isEmpty()) { // not a parameterized
+                    TypeElement e = (TypeElement) t.asElement();
+                    return ClassRef.from(e);
+                }
+                // TODO
+                throw new IllegalArgumentException(t.toString());
+            }
+
+            @Override
+            public TypeRef visitError(ErrorType t, Void p) {
+                throw new IllegalStateException("Unresolved type: " + t);
+            }
+
+            @Override
+            public TypeRef visitNoType(NoType t, Void p) {
+                if (t.getKind() == TypeKind.VOID) return PrimitiveTypeRef.VOID;
+                return visitUnknown(t, p);
+            }
+
+            @Override
+            protected TypeRef defaultAction(TypeMirror e, Void p) {
+                throw new IllegalArgumentException("Unexpected type mirror: " + e);
+            }
+        };
+
+        return typeMirror.accept(visitor, null);
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/SeparableRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/SeparableRenderer.java
@@ -1,0 +1,6 @@
+package telegram4j.tl.generator.renderer;
+
+public interface SeparableRenderer<P> extends CompletableRenderer<P> {
+
+    <T extends CompletableRenderer<?>> boolean separate(T child);
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/TopLevelRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/TopLevelRenderer.java
@@ -1,0 +1,377 @@
+package telegram4j.tl.generator.renderer;
+
+import telegram4j.tl.generator.Preconditions;
+
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Type;
+import java.util.*;
+
+import static telegram4j.tl.generator.renderer.CompletableRenderer.Stage.PROCESSING;
+
+@SuppressWarnings("unchecked")
+public class TopLevelRenderer extends BaseClassRenderer<CharSequence> {
+
+    protected final SortedSet<String> imports = new TreeSet<>(); // qualified name to simple name
+    protected final SortedSet<String> staticImports = new TreeSet<>();
+    protected final Map<String, String> simpleNames = new HashMap<>();
+
+    protected TopLevelRenderer(ClassRef name, ClassRenderer.Kind kind, CharSink out) {
+        super(name, kind, out);
+    }
+
+    private void addType0(TypeRef type) {
+        if (type instanceof PrimitiveTypeRef || type.equals(name)) return;
+
+        if (type instanceof ArrayRef) {
+            ArrayRef a = (ArrayRef) type;
+
+            addType0(a.component);
+        } else if (type instanceof ClassRef) {
+            ClassRef c = (ClassRef) type;
+
+            String simpleName = c.toString();
+            if (c.name.equals(name.name) && !c.packageName.equals(name.packageName) ||
+                    c.packageName.equals("java.lang") ||
+                    c.packageName.isEmpty() ||
+                    simpleNames.containsKey(simpleName)) {
+                return;
+            }
+
+            if (simpleNames.putIfAbsent(simpleName, c.packageName) == null) {
+                imports.add(c.qualifiedName());
+            }
+        } else if (type instanceof ParameterizedTypeRef) {
+            ParameterizedTypeRef p = (ParameterizedTypeRef) type;
+
+            addType0(p.rawType);
+            for (TypeRef typeArgument : p.typeArguments) {
+                addType0(typeArgument);
+            }
+        } else if (type instanceof TypeVariableRef) {
+            TypeVariableRef t = (TypeVariableRef) type;
+
+            for (TypeRef bound : t.bounds) {
+                addType0(bound);
+            }
+        } else if (type instanceof WildcardTypeRef) {
+            WildcardTypeRef w = (WildcardTypeRef) type;
+            if (w.upperBound != null) addType0(w.upperBound);
+            if (w.lowerBound != null) addType0(w.lowerBound);
+        } else if (type instanceof AnnotatedTypeRef) {
+            AnnotatedTypeRef a = (AnnotatedTypeRef) type;
+
+            addType0(a.type);
+            for (TypeRef ann : a.annotations) {
+                addType0(ann);
+            }
+        }
+    }
+
+    private void resolve(CharSink out, TypeRef type, boolean varargs) {
+        String varargsSuffix = varargs ? "..." : "";
+
+        // no qualification is needed
+        if (type instanceof PrimitiveTypeRef || type.equals(name)) {
+            out.append(type).append(varargsSuffix);
+            return;
+        }
+
+        if (type instanceof ArrayRef) {
+            ArrayRef a = (ArrayRef) type;
+
+            resolve(out, a.component, false);
+
+            String arraySuffix = varargs
+                    ? "[]".repeat(a.dimensions - 1) + "..."
+                    : "[]".repeat(a.dimensions);
+
+            out.append(arraySuffix);
+        } else if (type instanceof ClassRef) {
+            ClassRef c = (ClassRef) type;
+            String simpleName = c.toString();
+            String pckg = simpleNames.get(simpleName);
+
+
+            if (c.name.equals(name.name) && !c.packageName.equals(name.packageName)) {
+                out.append(c.qualifiedName()).append(varargsSuffix);
+                return;
+            }
+
+            if ((c.packageName.equals("java.lang") ||
+                // c.packageName.equals(name.packageName) ||
+                // simpleName.equals(name.name) ||
+                c.packageName.isEmpty()) &&
+                (pckg == null || pckg.equals(c.packageName))) {
+                out.append(simpleName).append(varargsSuffix);
+                return;
+            }
+
+            if (pckg != null && !pckg.equals(c.packageName)) { // fix name collision
+                out.append(c.qualifiedName()).append(varargsSuffix);
+                return;
+            }
+
+            out.append(simpleName).append(varargsSuffix);
+        } else if (type instanceof ParameterizedTypeRef) {
+            ParameterizedTypeRef p = (ParameterizedTypeRef) type;
+
+            resolve(out, p.rawType, false);
+            if (!p.typeArguments.isEmpty()) {
+                out.append('<');
+                for (int i = 0, n = p.typeArguments.size(); i < n; i++) {
+                    resolve(out, p.typeArguments.get(i), false);
+
+                    if (i != n - 1) {
+                        out.append(", ").lw();
+                    }
+                }
+                out.append('>');
+            }
+
+            out.append(varargsSuffix);
+        } else if (type instanceof AnnotatedTypeRef) {
+            AnnotatedTypeRef a = (AnnotatedTypeRef) type;
+
+            for (ClassRef annotation : a.annotations) {
+                out.append('@');
+                resolve(out, annotation, false);
+                out.append(' ');
+            }
+
+            resolve(out, a.type, varargs);
+        } else if (type instanceof TypeVariableRef) {
+            TypeVariableRef t = (TypeVariableRef) type;
+
+            out.append(t.name);
+            if (!t.bounds.isEmpty()) {
+                out.append('<');
+                for (int i = 0, n = t.bounds.size(); i < n; i++) {
+                    TypeRef bound = t.bounds.get(i);
+
+                    if (i == 0) {
+                        out.append(" extends ");
+                    } else {
+                        out.append(" & ");
+                    }
+
+                    resolve(out, bound, false);
+                }
+                out.append('>');
+            }
+        } else if (type instanceof WildcardTypeRef) {
+            WildcardTypeRef w = (WildcardTypeRef) type;
+
+            if (w.lowerBound != null) {
+                out.append("? super ");
+
+                resolve(out, w.lowerBound, false);
+            } else if (w.upperBound != null) {
+                out.append("? extends ");
+
+                resolve(out, w.upperBound, false);
+            } else {
+                out.append('?');
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown TypeRef: " + type);
+        }
+    }
+
+    @Override
+    protected void appendType(CharSink out, TypeRef type, boolean vararg) {
+        addType0(type);
+
+        resolve(out, type, vararg);
+    }
+
+    @Override
+    protected void appendType(CharSink out, TypeRef type) {
+        addType0(type);
+
+        resolve(out, type, false);
+    }
+
+    @Override
+    public TopLevelRenderer addStaticImports(String... staticImports) {
+        Collections.addAll(this.staticImports, staticImports);
+        return this;
+    }
+
+    @Override
+    public TopLevelRenderer addStaticImport(String staticImport) {
+        staticImports.add(staticImport);
+        return this;
+    }
+
+    // writers
+
+    @Override
+    public TopLevelRenderer addTypeVariables(TypeVariableRef first, TypeVariableRef... rest) {
+        return (TopLevelRenderer) super.addTypeVariables(first, rest);
+    }
+
+    @Override
+    public TopLevelRenderer addTypeVariables(Collection<TypeVariableRef> types) {
+        return (TopLevelRenderer) super.addTypeVariables(types);
+    }
+
+    @Override
+    public TopLevelRenderer addAnnotations(Type... annotations) {
+        return (TopLevelRenderer) super.addAnnotations(annotations);
+    }
+
+    @Override
+    public TopLevelRenderer addAnnotations(Collection<? extends Type> annotations) {
+        return (TopLevelRenderer) super.addAnnotations(annotations);
+    }
+
+    @Override
+    public TopLevelRenderer addAnnotations(boolean inline, Collection<? extends Type> annotations) {
+        return (TopLevelRenderer) super.addAnnotations(inline, annotations);
+    }
+
+    @Override
+    public TopLevelRenderer addModifiers(Modifier... modifiers) {
+        return (TopLevelRenderer) super.addModifiers(modifiers);
+    }
+
+    @Override
+    public TopLevelRenderer addSuperType(Type type) {
+        return (TopLevelRenderer) super.addSuperType(type);
+    }
+
+    @Override
+    public TopLevelRenderer addInterface(Type type) {
+        return (TopLevelRenderer) super.addInterface(type);
+    }
+
+    @Override
+    public TopLevelRenderer addInterfaces(List<? extends Type> types) {
+        return (TopLevelRenderer) super.addInterfaces(types);
+    }
+
+    @Override
+    public TopLevelRenderer addInterfaces(Type first, Type... rest) {
+        return (TopLevelRenderer) super.addInterfaces(first, rest);
+    }
+
+    @Override
+    public TopLevelRenderer addAttribute(Type type, String name) {
+        return (TopLevelRenderer) super.addAttribute(type, name);
+    }
+
+    @Override
+    public TopLevelRenderer addAttribute(Type type, String name, CharSequence format, Object... args) {
+        return (TopLevelRenderer) super.addAttribute(type, name, format, args);
+    }
+
+    @Override
+    public InitializerRenderer<TopLevelRenderer> addStaticInitializer() {
+        Preconditions.requireState(kind == ClassRenderer.Kind.CLASS || kind == ClassRenderer.Kind.ENUM,
+                "Static initializers is not allowed in " + kind);
+        completeStage(PROCESSING);
+        requireStage(PROCESSING);
+        return addPending(new InitializerRenderer<>(this, true));
+    }
+
+    @Override
+    public InitializerRenderer<TopLevelRenderer> addInitializer() {
+        Preconditions.requireState(kind == ClassRenderer.Kind.CLASS || kind == ClassRenderer.Kind.ENUM,
+                "Static initializers is not allowed in " + kind);
+        completeStage(PROCESSING);
+        requireStage(PROCESSING);
+        return addPending(new InitializerRenderer<>(this, false));
+    }
+
+    @Override
+    public FieldRenderer<TopLevelRenderer> addField(Type type, String name) {
+        return (FieldRenderer<TopLevelRenderer>) super.addField(type, name);
+    }
+
+    @Override
+    public FieldRenderer<TopLevelRenderer> addField(Type type, String name, Modifier... modifiers) {
+        return (FieldRenderer<TopLevelRenderer>) super.addField(type, name, modifiers);
+    }
+
+    @Override
+    public ExecutableRenderer<TopLevelRenderer> addConstructor() {
+        return (ExecutableRenderer<TopLevelRenderer>) super.addConstructor();
+    }
+
+    @Override
+    public ExecutableRenderer<TopLevelRenderer> addConstructor(Modifier... modifiers) {
+        return (ExecutableRenderer<TopLevelRenderer>) super.addConstructor(modifiers);
+    }
+
+    @Override
+    public MethodRenderer<TopLevelRenderer> addMethod(Type returnType, String name) {
+        return (MethodRenderer<TopLevelRenderer>) super.addMethod(returnType, name);
+    }
+
+    @Override
+    public MethodRenderer<TopLevelRenderer> addMethod(Type returnType, String name, Modifier... modifiers) {
+        return (MethodRenderer<TopLevelRenderer>) super.addMethod(returnType, name, modifiers);
+    }
+
+    @Override
+    public TopLevelRenderer addConstant(CharSequence name, CharSequence format, Object... args) {
+        return (TopLevelRenderer) super.addConstant(name, format, args);
+    }
+
+    @Override
+    public TopLevelRenderer addConstant(CharSequence name) {
+        return (TopLevelRenderer) super.addConstant(name);
+    }
+
+    public ClassRenderer<TopLevelRenderer> addType(String name, ClassRenderer.Kind kind) {
+        completeStage(PROCESSING);
+        requireStage(PROCESSING);
+        return addPending(new ClassRenderer<>(this.name.nested(name), kind, this, this));
+    }
+
+    @Override
+    public CharSequence complete() {
+        if (stage != Stage.COMPLETE) {
+            completePending();
+            complete0();
+
+            stage = Stage.COMPLETE;
+            postProcess();
+        }
+        return out.asStringBuilder();
+    }
+
+    private void postProcess() {
+        StringBuilder header = new StringBuilder();
+        if (!name.packageName.isEmpty()) {
+            header.append("package ");
+            header.append(name.packageName);
+            header.append(";\n\n");
+        }
+
+        if (!imports.isEmpty()) {
+            for (String anImport : imports) {
+                header.append("import ");
+                header.append(anImport);
+                header.append(";\n");
+            }
+            header.append('\n');
+        }
+
+        if (!staticImports.isEmpty()) {
+            for (String staticImport : staticImports) {
+                header.append("import static ");
+                header.append(staticImport);
+                header.append(";\n");
+            }
+
+            header.append('\n');
+        }
+
+        imports.clear();
+        staticImports.clear();
+        simpleNames.clear();
+
+        out.buf.insert(0, header);
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/TopLevelRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/TopLevelRenderer.java
@@ -216,6 +216,11 @@ public class TopLevelRenderer extends BaseClassRenderer<CharSequence> {
     }
 
     @Override
+    public TopLevelRenderer addAnnotation(AnnotationRenderer renderer) {
+        return (TopLevelRenderer) super.addAnnotation(renderer);
+    }
+
+    @Override
     public TopLevelRenderer addAnnotations(Type... annotations) {
         return (TopLevelRenderer) super.addAnnotations(annotations);
     }

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/TopLevelRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/TopLevelRenderer.java
@@ -3,6 +3,7 @@ package telegram4j.tl.generator.renderer;
 import telegram4j.tl.generator.Preconditions;
 
 import javax.lang.model.element.Modifier;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.*;
 
@@ -29,7 +30,8 @@ public class TopLevelRenderer extends BaseClassRenderer<CharSequence> {
         } else if (type instanceof ClassRef) {
             ClassRef c = (ClassRef) type;
 
-            String simpleName = c.toString();
+            String simpleName = c.name;
+
             if (c.name.equals(name.name) && !c.packageName.equals(name.packageName) ||
                     c.packageName.equals("java.lang") ||
                     c.packageName.isEmpty() ||
@@ -38,6 +40,7 @@ public class TopLevelRenderer extends BaseClassRenderer<CharSequence> {
             }
 
             if (simpleNames.putIfAbsent(simpleName, c.packageName) == null) {
+                // TODO handle collisions via enclosing class name
                 imports.add(c.qualifiedName());
             }
         } else if (type instanceof ParameterizedTypeRef) {
@@ -88,18 +91,15 @@ public class TopLevelRenderer extends BaseClassRenderer<CharSequence> {
             out.append(arraySuffix);
         } else if (type instanceof ClassRef) {
             ClassRef c = (ClassRef) type;
-            String simpleName = c.toString();
-            String pckg = simpleNames.get(simpleName);
-
+            String simpleName = c.name;
 
             if (c.name.equals(name.name) && !c.packageName.equals(name.packageName)) {
                 out.append(c.qualifiedName()).append(varargsSuffix);
                 return;
             }
 
+            String pckg = simpleNames.get(simpleName);
             if ((c.packageName.equals("java.lang") ||
-                // c.packageName.equals(name.packageName) ||
-                // simpleName.equals(name.name) ||
                 c.packageName.isEmpty()) &&
                 (pckg == null || pckg.equals(c.packageName))) {
                 out.append(simpleName).append(varargsSuffix);
@@ -221,12 +221,12 @@ public class TopLevelRenderer extends BaseClassRenderer<CharSequence> {
     }
 
     @Override
-    public TopLevelRenderer addAnnotations(Type... annotations) {
-        return (TopLevelRenderer) super.addAnnotations(annotations);
+    public TopLevelRenderer addAnnotation(Class<? extends Annotation> annotation) {
+        return (TopLevelRenderer) super.addAnnotation(annotation);
     }
 
     @Override
-    public TopLevelRenderer addAnnotations(Collection<? extends Type> annotations) {
+    public TopLevelRenderer addAnnotations(Iterable<Class<? extends Annotation>> annotations) {
         return (TopLevelRenderer) super.addAnnotations(annotations);
     }
 

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/TopLevelRenderer.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/TopLevelRenderer.java
@@ -231,11 +231,6 @@ public class TopLevelRenderer extends BaseClassRenderer<CharSequence> {
     }
 
     @Override
-    public TopLevelRenderer addAnnotations(boolean inline, Collection<? extends Type> annotations) {
-        return (TopLevelRenderer) super.addAnnotations(inline, annotations);
-    }
-
-    @Override
     public TopLevelRenderer addModifiers(Modifier... modifiers) {
         return (TopLevelRenderer) super.addModifiers(modifiers);
     }

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/TypeRef.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/TypeRef.java
@@ -1,0 +1,46 @@
+package telegram4j.tl.generator.renderer;
+
+import javax.lang.model.type.TypeMirror;
+import java.lang.reflect.Type;
+import java.util.Locale;
+import java.util.Objects;
+
+public interface TypeRef extends Type {
+
+    default TypeRef safeBox() {
+        return this;
+    }
+
+    default TypeRef safeUnbox() {
+        return this;
+    }
+
+    static TypeRef from(TypeMirror typeMirror) {
+        return RenderUtils.from(typeMirror);
+    }
+
+    static TypeRef of(Type type) {
+        Objects.requireNonNull(type);
+        if (type instanceof TypeRef) {
+            return (TypeRef) type;
+        } else if (type instanceof Class) {
+            Class<?> klass = (Class<?>) type;
+
+            if (klass.isArray()) {
+                Class<?> cl = klass;
+                short dimensions = 0;
+                do {
+                    dimensions++;
+                    cl = cl.getComponentType();
+                } while (cl.isArray());
+
+                return ArrayRef.of(of(cl), dimensions);
+            } else if (klass.isPrimitive()) {
+                return PrimitiveTypeRef.valueOf(klass.getName().toUpperCase(Locale.US));
+            }
+            return ClassRef.of(klass);
+        }
+
+        throw new IllegalArgumentException("Unexpected type: " + type);
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/TypeVariableRef.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/TypeVariableRef.java
@@ -1,0 +1,54 @@
+package telegram4j.tl.generator.renderer;
+
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class TypeVariableRef implements TypeRef {
+    public final String name;
+    public final List<TypeRef> bounds;
+
+    private TypeVariableRef(String name, List<TypeRef> bounds) {
+        this.name = Objects.requireNonNull(name);
+        this.bounds = Objects.requireNonNull(bounds);
+    }
+
+    public static TypeVariableRef of(String name) {
+        return new TypeVariableRef(name, List.of());
+    }
+
+    public static TypeVariableRef of(String name, TypeRef... bounds) {
+        return new TypeVariableRef(name, List.of(bounds));
+    }
+
+    public static TypeVariableRef of(String name, Collection<? extends TypeRef> bounds) {
+        return new TypeVariableRef(name, List.copyOf(bounds));
+    }
+
+    public static TypeVariableRef of(String name, Type... bounds) {
+        return new TypeVariableRef(name, Arrays.stream(bounds)
+                .map(TypeRef::of)
+                .collect(Collectors.toUnmodifiableList()));
+    }
+
+    public TypeVariableRef withBounds(Type... bounds) {
+        return new TypeVariableRef(name, Arrays.stream(bounds)
+                .map(TypeRef::of)
+                .collect(Collectors.toUnmodifiableList()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TypeVariableRef that = (TypeVariableRef) o;
+        return name.equals(that.name) && bounds.equals(that.bounds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, bounds);
+    }
+
+    // TODO implement toString
+}

--- a/parser/src/main/java/telegram4j/tl/generator/renderer/WildcardTypeRef.java
+++ b/parser/src/main/java/telegram4j/tl/generator/renderer/WildcardTypeRef.java
@@ -1,0 +1,101 @@
+package telegram4j.tl.generator.renderer;
+
+import reactor.util.annotation.Nullable;
+
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.WildcardType;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+public class WildcardTypeRef implements TypeRef {
+    private static final WildcardTypeRef NONE = new WildcardTypeRef(null, null);
+
+    @Nullable
+    public final TypeRef upperBound;
+    @Nullable
+    public final TypeRef lowerBound;
+
+    private WildcardTypeRef(@Nullable TypeRef upperBound, @Nullable TypeRef lowerBound) {
+        this.upperBound = upperBound;
+        this.lowerBound = lowerBound;
+    }
+
+    public static WildcardTypeRef none() {
+        return NONE;
+    }
+
+    public static WildcardTypeRef subtypeOf(@Nullable TypeRef upperBound) {
+        if (upperBound == null) {
+            return NONE;
+        }
+        return new WildcardTypeRef(upperBound, null);
+    }
+
+    public static WildcardTypeRef subtypeOf(@Nullable Type upperBound) {
+        if (upperBound == null) {
+            return NONE;
+        }
+        return new WildcardTypeRef(TypeRef.of(upperBound), null);
+    }
+
+    public static WildcardTypeRef supertypeOf(@Nullable TypeRef lowerBound) {
+        if (lowerBound == null) {
+            return NONE;
+        }
+        return new WildcardTypeRef(null, lowerBound);
+    }
+
+    public static WildcardTypeRef supertypeOf(@Nullable Type lowerBound) {
+        if (lowerBound == null) {
+            return NONE;
+        }
+        return new WildcardTypeRef(null, TypeRef.of(lowerBound));
+    }
+
+    public boolean isNoBounds() {
+        return upperBound == null && lowerBound == null;
+    }
+
+    public boolean isSubtypeBounded() {
+        return upperBound != null;
+    }
+
+    public boolean isSuperTypeBounded() {
+        return lowerBound != null;
+    }
+
+    protected String toString0(Function<TypeRef, String> toString) {
+        if (lowerBound != null) {
+            return "? super " + toString.apply(lowerBound);
+        } else if (upperBound != null) {
+            return "? extends " + toString.apply(upperBound);
+        } else {
+            return "?";
+        }
+    }
+
+    @Override
+    public String getTypeName() {
+        return toString0(Type::getTypeName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(upperBound, lowerBound);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WildcardTypeRef that = (WildcardTypeRef) o;
+        return Objects.equals(upperBound, that.upperBound) && Objects.equals(lowerBound, that.lowerBound);
+    }
+
+    @Override
+    public String toString() {
+        return toString0(Type::toString);
+    }
+}

--- a/parser/src/main/java/telegram4j/tl/parser/SchemaUpdater.java
+++ b/parser/src/main/java/telegram4j/tl/parser/SchemaUpdater.java
@@ -129,9 +129,11 @@ class SchemaUpdater {
     static Mono<Void> handleJsonScheme(String str, String filename) {
         return Mono.fromCallable(() -> mapper.readTree(str))
                 .doOnNext(SchemaUpdater::applyModification)
-                .flatMap(tree -> Mono.fromCallable(() -> mapper.writerWithDefaultPrettyPrinter()
-                        .writeValues(new File(pathPrefix + filename))
-                        .write(tree)))
+                .flatMap(tree -> Mono.fromCallable(() -> {
+                    mapper.writerWithDefaultPrettyPrinter()
+                            .writeValue(new File(pathPrefix + filename), tree);
+                    return null;
+                }))
                 .then();
     }
 

--- a/parser/src/main/java/telegram4j/tl/parser/TypeDeserializer.java
+++ b/parser/src/main/java/telegram4j/tl/parser/TypeDeserializer.java
@@ -20,11 +20,11 @@ class TypeDeserializer extends StdDeserializer<Type> {
     public Type deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         JsonNode node = p.readValueAsTree();
         Type.Kind kind = node.has("predicate") ? Type.Kind.CONSTRUCTOR : Type.Kind.METHOD;
-        String name = node.get(kind == Type.Kind.CONSTRUCTOR ? "predicate" : "method").asText();
-        String id = node.get("id").asText();
-        List<TlTrees.Parameter> params = ctxt.readTreeAsValue(node.get("params"), ctxt.getTypeFactory()
+        String name = node.required(kind == Type.Kind.CONSTRUCTOR ? "predicate" : "method").asText();
+        String id = node.required("id").asText();
+        List<TlTrees.Parameter> params = ctxt.readTreeAsValue(node.required("params"), ctxt.getTypeFactory()
                 .constructCollectionType(List.class, Parameter.class));
-        String type = node.get("type").asText();
+        String type = node.required("type").asText();
 
         return ImmutableTlTrees.Type.builder()
                 .kind(kind)

--- a/parser/src/main/resources/package-info.template
+++ b/parser/src/main/resources/package-info.template
@@ -1,14 +1,4 @@
-@Value.Style(
-        depluralize = true,
-        jdkOnly = true,
-        allMandatoryParameters = true,
-        defaultAsDefault = true,
-        allowedClasspathAnnotations = {Override.class}
-)
 @NonNullApi
-@TlEncodingsEnabled
 package ${package-name};
 
-import org.immutables.value.Value;
 import reactor.util.annotation.NonNullApi;
-import telegram4j.tl.encoding.TlEncodingsEnabled;

--- a/src/main/java/telegram4j/tl/BaseMessageFields.java
+++ b/src/main/java/telegram4j/tl/BaseMessageFields.java
@@ -22,9 +22,6 @@ public interface BaseMessageFields extends Message {
     Peer peerId();
 
     @Nullable
-    MessageFwdHeader fwdFrom();
-
-    @Nullable
     MessageReplyHeader replyTo();
 
     int date();

--- a/src/main/java/telegram4j/tl/ChatPhotoFields.java
+++ b/src/main/java/telegram4j/tl/ChatPhotoFields.java
@@ -4,8 +4,6 @@ import io.netty.buffer.ByteBuf;
 import reactor.util.annotation.Nullable;
 import telegram4j.tl.api.TlObject;
 
-import java.util.Optional;
-
 public interface ChatPhotoFields extends TlObject {
 
     int flags();
@@ -14,7 +12,8 @@ public interface ChatPhotoFields extends TlObject {
 
     long photoId();
 
-    Optional<ByteBuf> strippedThumb();
+    @Nullable
+    ByteBuf strippedThumb();
 
     int dcId();
 }

--- a/src/main/java/telegram4j/tl/json/TlModule.java
+++ b/src/main/java/telegram4j/tl/json/TlModule.java
@@ -1,0 +1,225 @@
+package telegram4j.tl.json;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.fasterxml.jackson.databind.ser.Serializers;
+import telegram4j.tl.TlInfo;
+import telegram4j.tl.api.TlObject;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class TlModule extends Module {
+
+    @Override
+    public String getModuleName() {
+        return "TlModule";
+    }
+
+    @Override
+    public Version version() {
+        return new Version(0, 1, 2, null, null, null);
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        context.addSerializers(new Serializers.Base() {
+            @Override
+            public JsonSerializer<?> findSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+                if (!type.isTypeOrSubTypeOf(TlObject.class)) {
+                    return null;
+                }
+
+                return new TlJsonSerializer(beanDesc);
+            }
+        });
+        context.addBeanDeserializerModifier(new BeanDeserializerModifier() {
+            @Override
+            public JsonDeserializer<?> modifyEnumDeserializer(DeserializationConfig config, JavaType type,
+                                                              BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+                if (!beanDesc.getType().isTypeOrSubTypeOf(TlObject.class)) {
+                    return deserializer;
+                }
+                return new TlJsonDeserializer(beanDesc);
+            }
+
+            @Override
+            public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription beanDesc,
+                                                          JsonDeserializer<?> deserializer) {
+                if (!beanDesc.getType().isTypeOrSubTypeOf(TlObject.class)) {
+                    return deserializer;
+                }
+                return new TlJsonDeserializer(beanDesc);
+            }
+        });
+    }
+
+    static class TlJsonDeserializer extends JsonDeserializer<TlObject> {
+
+        private final BeanDescription beanDesc;
+
+        TlJsonDeserializer(BeanDescription beanDesc) {
+            this.beanDesc = beanDesc;
+        }
+
+        @Override
+        public TlObject deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (p.currentToken() == JsonToken.START_OBJECT) p.nextToken();
+            if (!"identifier".equals(p.currentName()) || p.nextToken() != JsonToken.VALUE_NUMBER_INT) {
+                return ctxt.reportInputMismatch(this, "expected 'identifier' as first, but given '%s' with type %s",
+                        p.currentName(), p.currentToken());
+            }
+
+            int id = p.getIntValue();
+            p.nextToken();
+
+            JavaType type = ctxt.constructType(TlInfo.typeOf(id));
+            if (beanDesc.getType().isEnumType() || type.isEnumType()) {
+                if (!type.isTypeOrSubTypeOf(beanDesc.getType().getRawClass())) {
+                    throw new IllegalStateException(); // TODO:
+                }
+
+                try {
+                    Method ofMethod = type.getRawClass().getMethod("of", int.class);
+
+                    return (TlObject) ofMethod.invoke(null, id);
+                } catch (Exception e) {
+                    throw new IllegalStateException(e); // TODO
+                }
+            }
+
+            Object builder;
+            try {
+                Method builderMethod = type.getRawClass().getMethod("builder");
+                builder = builderMethod.invoke(null);
+            } catch (Exception e) {
+                try {
+                    Method m = type.getRawClass().getMethod("instance");
+                    return (TlObject) m.invoke(null);
+                } catch (Exception e1) {
+                    throw new IllegalArgumentException(e); // TODO:
+                }
+            }
+
+            var methods = Arrays.stream(builder.getClass().getMethods())
+                    .filter(m -> m.isAnnotationPresent(JsonSetter.class) ||
+                            m.getName().equals("build") && m.getParameterCount() == 0)
+                    .collect(Collectors.toMap(v -> {
+                        JsonSetter ann = v.getAnnotation(JsonSetter.class);
+                        return ann != null && !ann.value().isEmpty() ? ann.value() : v.getName();
+                    }, Function.identity()));
+
+            if (p.hasToken(JsonToken.FIELD_NAME)) {
+                String propName = p.currentName();
+                do {
+                    p.nextToken();
+                    Method prop = methods.get(propName);
+
+                    if (prop != null) { // normal case
+                        JavaType c = ctxt.constructType(prop.getGenericParameterTypes()[0]);
+                        if (p.hasToken(JsonToken.VALUE_NUMBER_INT) && c.isTypeOrSubTypeOf(TlObject.class)) {
+                            int propId = p.getIntValue();
+                            JavaType act = ctxt.constructSpecializedType(c, TlInfo.typeOf(propId));
+                            if (!act.isEnumType()) {
+                                try {
+                                    Method instanceMethod = act.getRawClass().getMethod("instance");
+                                    Object o = instanceMethod.invoke(null);
+                                    prop.invoke(builder, o);
+                                } catch (Exception e) {
+                                    throw new IllegalStateException(e); // TODO
+                                }
+                            } else {
+                                try {
+                                    Method ofMethod = act.getRawClass().getMethod("of", int.class);
+
+                                    Object o = ofMethod.invoke(null, propId);
+                                    prop.invoke(builder, o);
+                                } catch (Exception e) {
+                                    throw new IllegalStateException(e); // TODO
+                                }
+                            }
+
+                        } else {
+                            var deser = ctxt.findRootValueDeserializer(c);
+                            Object o = deser.deserialize(p, ctxt);
+                            try {
+                                prop.invoke(builder, o);
+                            } catch (Exception e) {
+                                throw new IllegalStateException(e); // TODO
+                            }
+                        }
+
+                        continue;
+                    }
+                    throw new IllegalStateException(); // TODO
+                } while ((propName = p.nextFieldName()) != null);
+            }
+
+            try {
+                Method m = methods.get("build");
+                return (TlObject) m.invoke(builder);
+            } catch (Exception e) {
+                throw new IllegalStateException(e); // TODO:
+            }
+        }
+    }
+
+    static class TlJsonSerializer extends JsonSerializer<TlObject> {
+
+        private final BeanDescription beanDesc;
+
+        protected TlJsonSerializer(BeanDescription beanDesc) {
+            this.beanDesc = beanDesc;
+        }
+
+        @Override
+        public void serialize(TlObject value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+            gen.writeNumberField("identifier", value.identifier());
+
+            serializeFields(value, gen, provider);
+
+            gen.writeEndObject();
+        }
+
+        protected void serializeFields(TlObject bean, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            for (BeanPropertyDefinition p : beanDesc.findProperties()) {
+                AnnotatedMember ac = p.getAccessor();
+                if (ac == null) {
+                    continue;
+                }
+
+                Object o = ac.getValue(bean);
+                if (o == null) {
+                    continue;
+                }
+
+                JavaType act = p.getPrimaryType().hasGenericTypes()
+                        ? provider.constructSpecializedType(p.getPrimaryType(), o.getClass())
+                        : p.getPrimaryType();
+
+                gen.writeFieldName(p.getName());
+                if (p.getPrimaryType().isTypeOrSubTypeOf(TlObject.class) &&
+                        (p.getPrimaryType().isEnumType() || provider.getConfig()
+                                .introspect(act).findProperties().isEmpty())) {
+                    TlObject c = (TlObject) o;
+                    gen.writeNumber(c.identifier());
+                } else {
+                    var ser = provider.findValueSerializer(act);
+                    ser.serialize(o, gen, provider);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/telegram4j/tl/json/TlModule.java
+++ b/src/main/java/telegram4j/tl/json/TlModule.java
@@ -1,20 +1,24 @@
 package telegram4j.tl.json;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.fasterxml.jackson.databind.ser.Serializers;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializerBase;
+import com.fasterxml.jackson.databind.util.ClassUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import telegram4j.tl.TlInfo;
 import telegram4j.tl.api.TlObject;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.function.Function;
@@ -37,10 +41,12 @@ public class TlModule extends Module {
         context.addSerializers(new Serializers.Base() {
             @Override
             public JsonSerializer<?> findSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+                if (type.isTypeOrSubTypeOf(ByteBuf.class)) {
+                    return ByteBufSerializer.instance;
+                }
                 if (!type.isTypeOrSubTypeOf(TlObject.class)) {
                     return null;
                 }
-
                 return new TlJsonSerializer(beanDesc);
             }
         });
@@ -57,6 +63,9 @@ public class TlModule extends Module {
             @Override
             public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription beanDesc,
                                                           JsonDeserializer<?> deserializer) {
+                if (beanDesc.getType().isTypeOrSubTypeOf(ByteBuf.class)) {
+                    return ByteBufDeserializer.instance;
+                }
                 if (!beanDesc.getType().isTypeOrSubTypeOf(TlObject.class)) {
                     return deserializer;
                 }
@@ -65,7 +74,42 @@ public class TlModule extends Module {
         });
     }
 
+    static class ByteBufDeserializer extends FromStringDeserializer<ByteBuf> {
+
+        private static final ByteBufDeserializer instance = new ByteBufDeserializer();
+
+        private ByteBufDeserializer() {
+            super(ByteBuf.class);
+        }
+
+        @Override
+        protected ByteBuf _deserialize(String value, DeserializationContext ctxt) {
+            return Unpooled.wrappedBuffer(ByteBufUtil.decodeHexDump(value));
+        }
+    }
+
+    static class ByteBufSerializer extends ToStringSerializerBase {
+
+        private static final ByteBufSerializer instance = new ByteBufSerializer();
+
+        private ByteBufSerializer() {
+            super(ByteBuf.class);
+        }
+
+        @Override
+        public boolean isEmpty(SerializerProvider prov, Object value) {
+            return !((ByteBuf) value).isReadable();
+        }
+
+        @Override
+        public String valueToString(Object value) {
+            return ByteBufUtil.hexDump((ByteBuf) value);
+        }
+    }
+
     static class TlJsonDeserializer extends JsonDeserializer<TlObject> {
+
+        static final Class<?>[] OF_METHOD_PARAMS = {int.class};
 
         private final BeanDescription beanDesc;
 
@@ -77,25 +121,23 @@ public class TlModule extends Module {
         public TlObject deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
             if (p.currentToken() == JsonToken.START_OBJECT) p.nextToken();
             if (!"identifier".equals(p.currentName()) || p.nextToken() != JsonToken.VALUE_NUMBER_INT) {
-                return ctxt.reportInputMismatch(this, "expected 'identifier' as first, but given '%s' with type %s",
+                return ctxt.reportInputMismatch(this, "Expected 'identifier' as first, but given '%s' with type %s",
                         p.currentName(), p.currentToken());
             }
 
             int id = p.getIntValue();
-            p.nextToken();
-
             JavaType type = ctxt.constructType(TlInfo.typeOf(id));
             if (beanDesc.getType().isEnumType() || type.isEnumType()) {
                 if (!type.isTypeOrSubTypeOf(beanDesc.getType().getRawClass())) {
-                    throw new IllegalStateException(); // TODO:
+                    throw ctxt.invalidTypeIdException(beanDesc.getType(), ClassUtil.getTypeDescription(type), "Not a subtype");
                 }
 
                 try {
-                    Method ofMethod = type.getRawClass().getMethod("of", int.class);
+                    Method ofMethod = type.getRawClass().getMethod("of", OF_METHOD_PARAMS);
 
                     return (TlObject) ofMethod.invoke(null, id);
-                } catch (Exception e) {
-                    throw new IllegalStateException(e); // TODO
+                } catch (Throwable e) {
+                    return wrapInstantiationProblem(e, ctxt);
                 }
             }
 
@@ -103,13 +145,15 @@ public class TlModule extends Module {
             try {
                 Method builderMethod = type.getRawClass().getMethod("builder");
                 builder = builderMethod.invoke(null);
-            } catch (Exception e) {
+            } catch (NoSuchMethodException e) {
                 try {
                     Method m = type.getRawClass().getMethod("instance");
                     return (TlObject) m.invoke(null);
                 } catch (Exception e1) {
-                    throw new IllegalArgumentException(e); // TODO:
+                    return wrapInstantiationProblem(e, ctxt);
                 }
+            } catch (Exception e) {
+                return wrapInstantiationProblem(e, ctxt);
             }
 
             var methods = Arrays.stream(builder.getClass().getMethods())
@@ -120,7 +164,7 @@ public class TlModule extends Module {
                         return ann != null && !ann.value().isEmpty() ? ann.value() : v.getName();
                     }, Function.identity()));
 
-            if (p.hasToken(JsonToken.FIELD_NAME)) {
+            if (p.nextToken() == JsonToken.FIELD_NAME) {
                 String propName = p.currentName();
                 do {
                     p.nextToken();
@@ -128,7 +172,7 @@ public class TlModule extends Module {
 
                     if (prop != null) { // normal case
                         JavaType c = ctxt.constructType(prop.getGenericParameterTypes()[0]);
-                        if (p.hasToken(JsonToken.VALUE_NUMBER_INT) && c.isTypeOrSubTypeOf(TlObject.class)) {
+                        if (p.hasToken(JsonToken.VALUE_NUMBER_INT) && c.isTypeOrSubTypeOf(TlObject.class)) { // simplified serialization
                             int propId = p.getIntValue();
                             JavaType act = ctxt.constructSpecializedType(c, TlInfo.typeOf(propId));
                             if (!act.isEnumType()) {
@@ -137,16 +181,16 @@ public class TlModule extends Module {
                                     Object o = instanceMethod.invoke(null);
                                     prop.invoke(builder, o);
                                 } catch (Exception e) {
-                                    throw new IllegalStateException(e); // TODO
+                                    wrapAndThrow(e, builder, propName, ctxt);
                                 }
                             } else {
                                 try {
-                                    Method ofMethod = act.getRawClass().getMethod("of", int.class);
+                                    Method ofMethod = act.getRawClass().getMethod("of", OF_METHOD_PARAMS);
 
                                     Object o = ofMethod.invoke(null, propId);
                                     prop.invoke(builder, o);
                                 } catch (Exception e) {
-                                    throw new IllegalStateException(e); // TODO
+                                    wrapAndThrow(e, builder, propName, ctxt);
                                 }
                             }
 
@@ -156,13 +200,13 @@ public class TlModule extends Module {
                             try {
                                 prop.invoke(builder, o);
                             } catch (Exception e) {
-                                throw new IllegalStateException(e); // TODO
+                                wrapAndThrow(e, builder, propName, ctxt);
                             }
                         }
 
                         continue;
                     }
-                    throw new IllegalStateException(); // TODO
+                    handleUnknownProperty(p, ctxt, builder, propName);
                 } while ((propName = p.nextFieldName()) != null);
             }
 
@@ -170,8 +214,71 @@ public class TlModule extends Module {
                 Method m = methods.get("build");
                 return (TlObject) m.invoke(builder);
             } catch (Exception e) {
-                throw new IllegalStateException(e); // TODO:
+                return wrapInstantiationProblem(e, ctxt);
             }
+        }
+
+        // methods below taken from the BeanDeserializerBase
+
+        public void wrapAndThrow(Throwable t, Object bean, String fieldName, DeserializationContext ctxt) throws IOException {
+            // Need to add reference information
+            throw JsonMappingException.wrapWithPath(throwOrReturnThrowable(t, ctxt), bean, fieldName);
+        }
+
+        private Throwable throwOrReturnThrowable(Throwable t, DeserializationContext ctxt) throws IOException {
+            /* 05-Mar-2009, tatu: But one nasty edge is when we get
+             *   StackOverflow: usually due to infinite loop. But that
+             *   often gets hidden within an InvocationTargetException...
+             */
+            while (t instanceof InvocationTargetException && t.getCause() != null) {
+                t = t.getCause();
+            }
+            // Errors to be passed as is
+            ClassUtil.throwIfError(t);
+            boolean wrap = ctxt == null || ctxt.isEnabled(DeserializationFeature.WRAP_EXCEPTIONS);
+            // Ditto for IOExceptions; except we may want to wrap JSON exceptions
+            if (t instanceof IOException) {
+                if (!wrap || !(t instanceof JacksonException)) {
+                    throw (IOException) t;
+                }
+            } else if (!wrap) { // [JACKSON-407] -- allow disabling wrapping for unchecked exceptions
+                ClassUtil.throwIfRTE(t);
+            }
+            return t;
+        }
+
+        protected TlObject wrapInstantiationProblem(Throwable t, DeserializationContext ctxt) throws IOException {
+            while (t instanceof InvocationTargetException && t.getCause() != null) {
+                t = t.getCause();
+            }
+            // Errors and "plain" IOExceptions to be passed as is
+            ClassUtil.throwIfError(t);
+            if (t instanceof IOException) {
+                // Since we have no more information to add, let's not actually wrap..
+                throw (IOException) t;
+            }
+            if (ctxt == null) { // only to please LGTM...
+                throw new IllegalArgumentException(t.getMessage(), t);
+            }
+            if (!ctxt.isEnabled(DeserializationFeature.WRAP_EXCEPTIONS)) {
+                ClassUtil.throwIfRTE(t);
+            }
+            return (TlObject) ctxt.handleInstantiationProblem(beanDesc.getType().getRawClass(), null, t);
+        }
+
+        protected void handleUnknownProperty(JsonParser p, DeserializationContext ctxt,
+                                             Object instanceOrClass, String propName) throws IOException {
+            if (instanceOrClass == null) {
+                instanceOrClass = handledType();
+            }
+            // Maybe we have configured handler(s) to take care of it?
+            if (ctxt.handleUnknownProperty(p, this, instanceOrClass, propName)) {
+                return;
+            }
+            /* But if we do get this far, need to skip whatever value we
+             * are pointing to now (although handler is likely to have done that already)
+             */
+            p.skipChildren();
         }
     }
 

--- a/src/main/java/telegram4j/tl/package-info.java
+++ b/src/main/java/telegram4j/tl/package-info.java
@@ -3,20 +3,10 @@
         @Configuration(name = "api"),
         @Configuration(name = "mtproto", packagePrefix = "mtproto", superType = MTProtoObject.class),
 })
-@Value.Style(
-        depluralize = true,
-        jdkOnly = true,
-        allMandatoryParameters = true,
-        defaultAsDefault = true,
-        allowedClasspathAnnotations = {Override.class}
-)
 @NonNullApi
-@TlEncodingsEnabled
 package telegram4j.tl;
 
-import org.immutables.value.Value;
 import reactor.util.annotation.NonNullApi;
 import telegram4j.tl.api.MTProtoObject;
-import telegram4j.tl.encoding.TlEncodingsEnabled;
 import telegram4j.tl.generator.GenerateSchema;
 import telegram4j.tl.generator.GenerateSchema.Configuration;

--- a/src/test/java/telegram4j/tl/ImmutableTest.java
+++ b/src/test/java/telegram4j/tl/ImmutableTest.java
@@ -1,0 +1,24 @@
+package telegram4j.tl;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class ImmutableTest {
+
+    @Test
+    void with() {
+        ImmutableBaseUser user = ImmutableBaseUser.of(0, 1337);
+
+        Assertions.assertSame(user, user.withFlags(0));
+        Assertions.assertSame(user, user.withBot(false));
+        Assertions.assertSame(user, user.withAccessHash(null));
+        var updated = user.withAccessHash(1L);
+        Assertions.assertSame(updated, updated.withAccessHash(1L));
+        Assertions.assertNotEquals(user, user.withRestrictionReason(List.of()));
+        var emptyReasons = user.withRestrictionReason(List.of());
+        Assertions.assertSame(emptyReasons, emptyReasons.withRestrictionReason(List.of()));
+        Assertions.assertSame(user, user.withRestrictionReason((Iterable<? extends RestrictionReason>) null));
+    }
+}

--- a/src/test/java/telegram4j/tl/ImmutableTest.java
+++ b/src/test/java/telegram4j/tl/ImmutableTest.java
@@ -23,5 +23,6 @@ class ImmutableTest {
         assertSame(user, user.withRestrictionReason((Iterable<? extends RestrictionReason>) null));
         assertSame(user.withFlags(BaseUser.ACCESS_HASH_MASK), user);
         assertNotEquals(user.withFlags(BaseUser.BOT_MASK), user);
+        assertNull(user.withFlags(BaseUser.BOT_MASK).botInfoVersion());
     }
 }

--- a/src/test/java/telegram4j/tl/ImmutableTest.java
+++ b/src/test/java/telegram4j/tl/ImmutableTest.java
@@ -1,9 +1,10 @@
 package telegram4j.tl;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class ImmutableTest {
 
@@ -11,14 +12,16 @@ class ImmutableTest {
     void with() {
         ImmutableBaseUser user = ImmutableBaseUser.of(0, 1337);
 
-        Assertions.assertSame(user, user.withFlags(0));
-        Assertions.assertSame(user, user.withBot(false));
-        Assertions.assertSame(user, user.withAccessHash(null));
+        assertSame(user, user.withFlags(0));
+        assertSame(user, user.withBot(false));
+        assertSame(user, user.withAccessHash(null));
         var updated = user.withAccessHash(1L);
-        Assertions.assertSame(updated, updated.withAccessHash(1L));
-        Assertions.assertNotEquals(user, user.withRestrictionReason(List.of()));
+        assertSame(updated, updated.withAccessHash(1L));
+        assertNotEquals(user, user.withRestrictionReason(List.of()));
         var emptyReasons = user.withRestrictionReason(List.of());
-        Assertions.assertSame(emptyReasons, emptyReasons.withRestrictionReason(List.of()));
-        Assertions.assertSame(user, user.withRestrictionReason((Iterable<? extends RestrictionReason>) null));
+        assertSame(emptyReasons, emptyReasons.withRestrictionReason(List.of()));
+        assertSame(user, user.withRestrictionReason((Iterable<? extends RestrictionReason>) null));
+        assertSame(user.withFlags(BaseUser.ACCESS_HASH_MASK), user);
+        assertNotEquals(user.withFlags(BaseUser.BOT_MASK), user);
     }
 }

--- a/src/test/java/telegram4j/tl/JsonSerializationTest.java
+++ b/src/test/java/telegram4j/tl/JsonSerializationTest.java
@@ -1,0 +1,52 @@
+package telegram4j.tl;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer;
+import org.junit.jupiter.api.Test;
+import telegram4j.tl.api.TlObject;
+import telegram4j.tl.json.TlModule;
+import telegram4j.tl.request.InvokeWithLayer;
+import telegram4j.tl.request.help.GetConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class JsonSerializationTest {
+
+    static final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new TlModule());
+
+    @Test
+    void allCases() throws Throwable {
+
+        assertSame(NotificationSoundNone.instance(), serialize(NotificationSoundNone.instance()));
+        assertSame(TopPeerCategory.BOTS_INLINE, serialize(TopPeerCategory.BOTS_INLINE));
+        var expAccountDaysTTL = AccountDaysTTL.builder()
+                .days(1213)
+                .build();
+        assertEquals(expAccountDaysTTL, serialize(expAccountDaysTTL));
+        var expInvokeWithLayer = InvokeWithLayer.builder()
+                .layer(1)
+                .query(GetConfig.instance())
+                .build();
+        assertEquals(expInvokeWithLayer, serialize(expInvokeWithLayer));
+        var expBaseUser = BaseUser.builder()
+                .id(7331)
+                .botInfoVersion(23)
+                .addRestrictionReason(RestrictionReason.builder()
+                        .platform("linux123456")
+                        .reason("a")
+                        .text("text")
+                        .build())
+                .build();
+        assertEquals(expBaseUser, serialize(expBaseUser));
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends TlObject> T serialize(T o) throws Throwable {
+        String s = mapper.writeValueAsString(o);
+        return (T) mapper.readValue(s, TlObject.class);
+    }
+}

--- a/src/test/java/telegram4j/tl/SerializationTest.java
+++ b/src/test/java/telegram4j/tl/SerializationTest.java
@@ -27,7 +27,7 @@ class SerializationTest {
         Channel expected = Channel.builder()
                 .id(1)
                 .title("title")
-                .photo(ImmutableChatPhotoEmpty.of())
+                .photo(ChatPhotoEmpty.instance())
                 .gigagroup(true)
                 .date(1)
                 .build();
@@ -46,7 +46,7 @@ class SerializationTest {
                 .date(1337)
                 .title("A!")
                 .id(10)
-                .photo(ImmutableChatPhotoEmpty.of())
+                .photo(ChatPhotoEmpty.instance())
                 .participantsCount(99)
                 .callNotEmpty(true)
                 .build();
@@ -106,7 +106,7 @@ class SerializationTest {
                 // flags - 4
                 .id(1) // 8
                 .title("title") // 8
-                .photo(ImmutableChatPhotoEmpty.of()) // 4
+                .photo(ChatPhotoEmpty.instance()) // 4
                 .date(1) // 4
                 .build();
 
@@ -118,7 +118,7 @@ class SerializationTest {
         Channel expected = Channel.builder()
                 .id(1)
                 .title("title")
-                .photo(ImmutableChatPhotoEmpty.of())
+                .photo(ChatPhotoEmpty.instance())
                 .gigagroup(true)
                 .date(1)
                 .build();
@@ -126,7 +126,7 @@ class SerializationTest {
         Channel actual = Channel.builder()
                 .id(1)
                 .title("title")
-                .photo(ImmutableChatPhotoEmpty.of())
+                .photo(ChatPhotoEmpty.instance())
                 .gigagroup(true)
                 .date(1)
                 .build();

--- a/src/test/java/telegram4j/tl/SerializationTest.java
+++ b/src/test/java/telegram4j/tl/SerializationTest.java
@@ -18,7 +18,7 @@ import java.util.zip.Deflater;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SerializationTest {
+class SerializationTest {
 
     static ByteBufAllocator alloc = UnpooledByteBufAllocator.DEFAULT;
 
@@ -27,7 +27,7 @@ public class SerializationTest {
         Channel expected = Channel.builder()
                 .id(1)
                 .title("title")
-                .photo(ChatPhotoEmpty.instance())
+                .photo(ImmutableChatPhotoEmpty.of())
                 .gigagroup(true)
                 .date(1)
                 .build();
@@ -46,7 +46,7 @@ public class SerializationTest {
                 .date(1337)
                 .title("A!")
                 .id(10)
-                .photo(ChatPhotoEmpty.instance())
+                .photo(ImmutableChatPhotoEmpty.of())
                 .participantsCount(99)
                 .callNotEmpty(true)
                 .build();
@@ -106,11 +106,34 @@ public class SerializationTest {
                 // flags - 4
                 .id(1) // 8
                 .title("title") // 8
-                .photo(ChatPhotoEmpty.instance()) // 4
+                .photo(ImmutableChatPhotoEmpty.of()) // 4
                 .date(1) // 4
                 .build();
 
         assertEquals(TlSerializer.sizeOf(expected), 32);
+    }
+
+    @Test
+    void objectMethods() {
+        Channel expected = Channel.builder()
+                .id(1)
+                .title("title")
+                .photo(ImmutableChatPhotoEmpty.of())
+                .gigagroup(true)
+                .date(1)
+                .build();
+
+        Channel actual = Channel.builder()
+                .id(1)
+                .title("title")
+                .photo(ImmutableChatPhotoEmpty.of())
+                .gigagroup(true)
+                .date(1)
+                .build();
+
+        assertEquals(expected.toString(), actual.toString());
+        assertEquals(expected, actual);
+        assertEquals(expected.hashCode(), actual.hashCode());
     }
 
     static <T extends TlObject> T serialize(T obj) {


### PR DESCRIPTION
Replace the Immutables generator with a self-written implementation and add json support.

**Motivation:** 
- Immutables although it is very flexible in functionality, but it is not ideal for our tasks.
- Reducing memory consumption through proper processing of bit-sets, collections and storing optional primitive values without boxing.
- Custom implementation of json serialization.

**Changes:**
- Now if the class has no fields, then only one class (not an interface) will be generated.
- Added generation of constants with bit masks.
- Changed generation of bit sets and flags. Now bit sets do not have a default implementation and bit flags are now just methods with bit-checks.